### PR TITLE
Refactor exporter to support domain-level properties, use class-based model for serialization

### DIFF
--- a/tools/data-model-exporter/data_model_exporter/__init__.py
+++ b/tools/data-model-exporter/data_model_exporter/__init__.py
@@ -1,5 +1,3 @@
 import logging
 
-
-# the builtin RDFLIB PROV NS does not define 'definition' for unknown reasons, hence this ad hoc def
 logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/tools/data-model-exporter/data_model_exporter/__init__.py
+++ b/tools/data-model-exporter/data_model_exporter/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+
+# the builtin RDFLIB PROV NS does not define 'definition' for unknown reasons, hence this ad hoc def
+logging.basicConfig(level=logging.INFO, format="%(message)s")

--- a/tools/data-model-exporter/data_model_exporter/common.py
+++ b/tools/data-model-exporter/data_model_exporter/common.py
@@ -1,4 +1,8 @@
-OPTIONAL_FIELD_VALUES_TO_OMIT = [
+from typing import Any
+
+
+# values that mean an optional field isn't defined and should be excluded from generated schema
+OPTIONAL_FIELD_VALUES_TO_OMIT: list[Any] = [
     "",
     None,
     list(),

--- a/tools/data-model-exporter/data_model_exporter/common.py
+++ b/tools/data-model-exporter/data_model_exporter/common.py
@@ -1,0 +1,7 @@
+OPTIONAL_FIELD_VALUES_TO_OMIT = [
+    "",
+    None,
+    list(),
+    dict(),
+    set(),
+]

--- a/tools/data-model-exporter/data_model_exporter/dmExporter.py
+++ b/tools/data-model-exporter/data_model_exporter/dmExporter.py
@@ -7,18 +7,12 @@
 import argparse
 import json
 import logging
-import sys
 from os import path
-from typing import Any
 
-from rdflib import Graph, Namespace, OWL, RDFS
+from .ttl_schema_generator import JsonSchema, TtlSchemaGenerator
 
-Terra = Namespace("http://datamodel.terra.bio/TerraDCAT_ap#")
 # the builtin RDFLIB PROV NS does not define 'definition' for unknown reasons, hence this ad hoc def
-Prov = Namespace("http://www.w3.org/ns/prov#")
 logging.basicConfig(level=logging.INFO, format="%(message)s")
-
-JsonSchema = dict[str, Any]
 
 
 def get_arguments() -> tuple[str, list[str]]:
@@ -32,101 +26,27 @@ def get_arguments() -> tuple[str, list[str]]:
         '--file-path',
         help="path to the data model e.g.: 'src/terra-core/TerraDCAT-AP.ttl'",
         required=True)
-    parser.add_argument(
+    class_list_source = parser.add_mutually_exclusive_group(required=True)
+    class_list_source.add_argument(
         '-l',
         '--class-list',
         nargs='+',
         help="a class listing string e.g.: 'DataCollection BiomedicalResearch'")
-    parser.add_argument('-c', '--class-path', help="a class listing file e.g.: 'class_name.txt'")
+    class_list_source.add_argument('-c', '--class-path', help="a class listing file e.g.: 'class_name.txt'")
     args = parser.parse_args()
 
-    if args.class_list is None and args.class_path is None:
-        logging.error("Provide a class_list 'l' or class_path 'c' argument")
-        sys.exit(1)
-    elif args.class_list and args.class_path:
-        logging.error("Provide a single class_list argument")
-        sys.exit(1)
-    elif args.class_list:
+    if args.class_list:
         return args.file_path, args.class_list
-    elif args.class_path:
-        class_list = []
-        class_count = 0
+    else:
         with open(args.class_path, 'r') as class_file:
-            for class_count, line in enumerate(class_file):
-                strip_line = line.strip()
-                if not strip_line:
-                    continue
-                class_list.append(strip_line)
-        logging.info(f"{class_count} classes parsed from {args.class_path}")
+            class_list = [
+                line.strip()
+                for line in class_file
+                if line.strip() != ""
+            ]
+        logging.info(f"{len(class_list)} classes parsed from {args.class_path}")
         logging.info(f"class_list: {class_list}")
         return args.file_path, class_list
-    else:
-        logging.error("Error parsing arguments, please try again...")
-        exit(1)
-
-
-def ttl_to_json(file_path: str, class_name: str) -> JsonSchema:
-    """
-    Reads ttl file from given file_path and pulls properties for the given class_name
-    :param file_path: File path to ttl file to read
-    :param class_name: Class name of class to grab properties from
-    :return: Json schema of given class
-    """
-    with open(file_path, 'r') as ttl_file:
-        rdf_term = Terra.term(class_name)
-        # parse the file
-        g = Graph()
-        g.parse(ttl_file, format='turtle')
-        properties = {
-            "describedBy": {
-                "description": "The URL reference to the JSON Schema that defines this object.",
-                "type": "string"
-            },
-            "id": {
-                "description": "UUID for this entity.",
-                "type": "string"
-            }
-        }
-        # 'required' properties are those with a cardinality of exactly 1, and the hardcoded 'id' property
-        required = ['id', 'describedBy']
-
-        # pull all RDF triples with the given rdf_term as the 'subject'
-        term_triples = g.triples((rdf_term, None, None))
-        for triple in term_triples:
-            # any OWL equivalentClass predicate is a 'property'
-            if triple[1] == OWL.equivalentClass:
-                # the 'object' node reached via the equivalentClass predicate is a 'blank node' in
-                # RDF; this node is anonymous and serves as a container for composite property information
-                container_node = triple[2]
-                cardinality = g.value(container_node, OWL.cardinality, None)
-                prop = g.value(container_node, OWL.onProperty, None)
-                # subject = container_node, predicate = OWL.onProperty, object)
-                ref = prop.n3(g.namespace_manager)
-
-                # this results in nulls for dct: terms
-                rdfs_range_value = g.value(prop, RDFS.range)
-                properties[prop.n3(g.namespace_manager)] = {
-                    'description': ref,
-                    '$ref': rdfs_range_value,
-                }
-
-                # should limit this to exactly 1 (take the cardinality seriously)
-                if cardinality and cardinality.value == 1:
-                    required.append(prop.n3(g.namespace_manager))
-
-        json_schema = {
-            '$id': rdf_term,
-            '$schema': "http://json-schema.org/draft-07/schema#/",
-            'title': g.value(rdf_term, RDFS.label),
-            # json convention uses a "description" field as the definition
-            'description': str(g.value(rdf_term, Prov.definition)),
-            'definitions': {},
-            'type': 'object',
-            'additionalProperties': True,
-            'properties': properties,
-            'required': required
-        }
-        return json_schema
 
 
 def rdf_to_json(file_path: str, class_list: list[str]) -> dict[str, JsonSchema]:
@@ -136,13 +56,17 @@ def rdf_to_json(file_path: str, class_list: list[str]) -> dict[str, JsonSchema]:
     :param class_list: List of classes to parse
     :return: Dictionary {key=class_name : value=json_schema}
     """
-    json_schema_list = {class_name: ttl_to_json(file_path, class_name) for class_name in class_list}
+    json_schema_list = {
+        class_name: TtlSchemaGenerator(class_name, file_path).build_schema()
+        for class_name in class_list
+    }
     return json_schema_list
 
 
 def write_to_json(out_file_name: str, json_dict: dict[str, JsonSchema], key: str) -> None:
+    logging.info(json.dumps(json_dict[key], indent=4))
+
     with open(out_file_name, 'w') as f:
-        logging.info(json.dumps(json_dict[key], indent=4))
         json.dump(json_dict[key], f)
 
 

--- a/tools/data-model-exporter/data_model_exporter/dmExporter.py
+++ b/tools/data-model-exporter/data_model_exporter/dmExporter.py
@@ -11,9 +11,6 @@ from os import path
 
 from .ttl_schema_generator import JsonSchema, TtlSchemaGenerator
 
-# the builtin RDFLIB PROV NS does not define 'definition' for unknown reasons, hence this ad hoc def
-logging.basicConfig(level=logging.INFO, format="%(message)s")
-
 
 def get_arguments() -> tuple[str, list[str]]:
     """Arguments defined in spec

--- a/tools/data-model-exporter/data_model_exporter/dmExporter.py
+++ b/tools/data-model-exporter/data_model_exporter/dmExporter.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-"""Create a basic CLI tool that parses the arg list defined in the spec
-(as linked in the parent epic) and hands off the args to a stub driver method
+"""
+A basic CLI tool that allows the class and file to parse to be specified and
+passes that information off to the schema generator
 """
 
 import argparse

--- a/tools/data-model-exporter/data_model_exporter/dmExporter.py
+++ b/tools/data-model-exporter/data_model_exporter/dmExporter.py
@@ -9,7 +9,7 @@ import json
 import logging
 from os import path
 
-from .ttl_schema_generator import JsonSchema, TtlSchemaGenerator
+from data_model_exporter.ttl_schema_generator import JsonSchema, TtlSchemaGenerator
 
 
 def get_arguments() -> tuple[str, list[str]]:

--- a/tools/data-model-exporter/data_model_exporter/property.py
+++ b/tools/data-model-exporter/data_model_exporter/property.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass, field
 import logging
 from typing import Any, Literal, Optional
 
-from .typing import ArrayFieldTypeInformation, JsonSchema, PropertyType, TypeListing, TypeInformation
+from .typing import ArrayTypeConstraintExpression, JsonSchema, PropertyType, RdfNodeName, \
+    SingletonTypeConstraintExpression, TypeConstraintExpression
 from .property_types import PrimitiveType, RefType
 
 
@@ -12,7 +13,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 @dataclass
 class Property:
     name: str
-    description: str  # should be initialized as un-namespaced uriref of property
+    description: str = ""
     comment: Optional[str] = None
     title: Optional[str] = None
     skos_preflabel: Optional[str] = None
@@ -20,24 +21,33 @@ class Property:
     allowed_values: list[str] = field(default_factory=list)
     min_cardinality: Optional[int] = None
     max_cardinality: Optional[int] = None
-    force_array_type: bool = False
     required: bool = False
     parent_properties: list[RefType] = field(default_factory=list)
 
     # some flags for internal validation that don't end up in the json
 
     # set to true if a single-type constraint has been applied
-    expect_no_further_type_constraints: bool = False
+    expect_no_further_type_constraints: bool = field(default=False, init=False, repr=False, compare=False)
+    description_already_set_by: Optional[RdfNodeName] = field(default=None, init=False, repr=False, compare=False)
+
+    def set_description(self, new_description: str, source: RdfNodeName) -> None:
+        if self.description_already_set_by:
+            logging.warning(
+                f"Setting description of property {self.name} to {new_description} (based on {source})"
+                f"when it has already been defined by {self.description_already_set_by}."
+            )
+
+        self.description = new_description
+        self.description_already_set_by = source
 
     def is_array_type(self) -> bool:
         return self.min_cardinality is not None \
-            or self.max_cardinality is not None \
-            or self.force_array_type
+            or self.max_cardinality is not None
 
     def add_type(self, new_type: PropertyType, restrictive: bool = False) -> None:
         if any(self.allowed_values):
             raise ValueError(
-                "Tried to add a type constraint for property {self.name}, which already has value constraints."
+                f"Tried to add a type constraint for property {self.name}, which already has value constraints."
             )
 
         if self.expect_no_further_type_constraints:
@@ -57,19 +67,19 @@ class Property:
 
         self.allowed_values.append(new_value)
 
-    def base_type_info(self) -> TypeListing:
+    def base_type_info(self) -> SingletonTypeConstraintExpression:
         type_count = len(self.allowed_types)
 
         if type_count == 0:
-            return PrimitiveType('string').type_entry()
+            return PrimitiveType('string').type_constraint_dict()
 
         if type_count == 1:
-            return self.allowed_types[0].type_entry()  # type: ignore
+            return self.allowed_types[0].type_constraint_dict()  # type: ignore
 
         one_of_literal: Literal['oneOf'] = 'oneOf'  # necessary for type annotations
         return {
             one_of_literal: [
-                allowed_type.type_entry()
+                allowed_type.type_constraint_dict()
                 for allowed_type in self.allowed_types
             ]
         }
@@ -83,7 +93,7 @@ class Property:
             'maxItems': self.max_cardinality,
             'oneOf': self.allowed_values,
             'rdfs:PropertyOf': [
-                parent_property.type_entry()
+                parent_property.type_constraint_dict()
                 for parent_property
                 in self.parent_properties
             ],
@@ -91,9 +101,9 @@ class Property:
 
         return {k: v for k, v in fields.items() if bool(v)}
 
-    def type_info(self) -> TypeInformation:
+    def type_info(self) -> TypeConstraintExpression:
         if self.is_array_type():
-            base_info = ArrayFieldTypeInformation({
+            base_info = ArrayTypeConstraintExpression({
                 'type': 'array',
                 'items': self.base_type_info()
             })

--- a/tools/data-model-exporter/data_model_exporter/property.py
+++ b/tools/data-model-exporter/data_model_exporter/property.py
@@ -1,3 +1,8 @@
+"""
+Intermediate representation for a property of a given class, including
+logic to serialize to JSON schema
+"""
+
 from dataclasses import dataclass, field
 import logging
 from typing import Any, Literal, Optional
@@ -26,6 +31,7 @@ class Property:
 
     # set to true if a single-type constraint has been applied
     expect_no_further_type_constraints: bool = field(default=False, init=False, repr=False, compare=False)
+    # determines if we already pulled in a description from another source
     description_already_set_by: Optional[RdfNodeName] = field(default=None, init=False, repr=False, compare=False)
 
     def set_description(self, new_description: str, source: RdfNodeName) -> None:

--- a/tools/data-model-exporter/data_model_exporter/property.py
+++ b/tools/data-model-exporter/data_model_exporter/property.py
@@ -74,6 +74,8 @@ class Property:
     def base_type_info(self) -> SingletonTypeConstraintExpression:
         type_count = len(self.allowed_types)
 
+        # defaulting to 'string' type is an assumption we're choosing to make for our JSON schema
+        # and not an inherent property of TTL schemas
         if type_count == 0:
             return PrimitiveType('string').type_constraint_dict()
 

--- a/tools/data-model-exporter/data_model_exporter/property.py
+++ b/tools/data-model-exporter/data_model_exporter/property.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Literal, Optional
+
+from .typing import ArrayFieldTypeInformation, JsonSchema, PropertyType, TypeListing, TypeInformation
+from .property_types import PrimitiveType, RefType
+
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+@dataclass
+class Property:
+    name: str
+    description: str  # should be initialized as un-namespaced uriref of property
+    comment: Optional[str] = None
+    title: Optional[str] = None
+    skos_preflabel: Optional[str] = None
+    allowed_types: list[PropertyType] = field(default_factory=list)
+    allowed_values: list[str] = field(default_factory=list)
+    min_cardinality: Optional[int] = None
+    max_cardinality: Optional[int] = None
+    force_array_type: bool = False
+    required: bool = False
+    parent_properties: list[RefType] = field(default_factory=list)
+
+    # some flags for internal validation that don't end up in the json
+
+    # set to true if a single-type constraint has been applied
+    expect_no_further_type_constraints: bool = False
+
+    def is_array_type(self) -> bool:
+        return self.min_cardinality is not None \
+            or self.max_cardinality is not None \
+            or self.force_array_type
+
+    def add_type(self, new_type: PropertyType, restrictive: bool = False) -> None:
+        if any(self.allowed_values):
+            raise ValueError(
+                "Tried to add a type constraint for property {self.name}, which already has value constraints."
+            )
+
+        if self.expect_no_further_type_constraints:
+            raise ValueError(
+                f"Found a new type constraint ({new_type.name}) for {self.name} when a previous restrictive constraint "
+                "has already been applied."
+            )
+
+        self.expect_no_further_type_constraints |= restrictive
+
+        if new_type not in self.allowed_types:
+            self.allowed_types.append(new_type)
+
+    def add_enum_value(self, new_value: str) -> None:
+        if any(self.allowed_types):
+            raise ValueError(f"Tried to enumerate values for property {self.name}, which already has type constraints.")
+
+        self.allowed_values.append(new_value)
+
+    def base_type_info(self) -> TypeListing:
+        type_count = len(self.allowed_types)
+
+        if type_count == 0:
+            return PrimitiveType('string').type_entry()
+
+        if type_count == 1:
+            return self.allowed_types[0].type_entry()  # type: ignore
+
+        one_of_literal: Literal['oneOf'] = 'oneOf'  # necessary for type annotations
+        return {
+            one_of_literal: [
+                allowed_type.type_entry()
+                for allowed_type in self.allowed_types
+            ]
+        }
+
+    def optional_fields(self) -> dict[str, Any]:
+        fields = {
+            'title': self.title,
+            'comment': self.comment,
+            'skos:prefLabel': self.skos_preflabel,
+            'minItems': self.min_cardinality,
+            'maxItems': self.max_cardinality,
+            'oneOf': self.allowed_values,
+            'rdfs:PropertyOf': [
+                parent_property.type_entry()
+                for parent_property
+                in self.parent_properties
+            ],
+        }
+
+        return {k: v for k, v in fields.items() if bool(v)}
+
+    def type_info(self) -> TypeInformation:
+        if self.is_array_type():
+            base_info = ArrayFieldTypeInformation({
+                'type': 'array',
+                'items': self.base_type_info()
+            })
+
+            return base_info
+
+        return self.base_type_info()
+
+    def as_dict(self) -> JsonSchema:
+        base_info = dict(self.type_info())  # manually cast to dict to enable key assignment
+        base_info.update(self.optional_fields())
+        base_info['description'] = self.description
+
+        return base_info

--- a/tools/data-model-exporter/data_model_exporter/property.py
+++ b/tools/data-model-exporter/data_model_exporter/property.py
@@ -2,12 +2,10 @@ from dataclasses import dataclass, field
 import logging
 from typing import Any, Literal, Optional
 
-from .typing import ArrayTypeConstraintExpression, JsonSchema, PropertyType, RdfNodeName, \
+from data_model_exporter.common import OPTIONAL_FIELD_VALUES_TO_OMIT
+from data_model_exporter.typing import ArrayTypeConstraintExpression, JsonSchema, PropertyType, RdfNodeName, \
     SingletonTypeConstraintExpression, TypeConstraintExpression
-from .property_types import PrimitiveType, RefType
-
-
-logging.basicConfig(level=logging.INFO, format="%(message)s")
+from data_model_exporter.property_types import PrimitiveType, RefType
 
 
 @dataclass
@@ -99,7 +97,7 @@ class Property:
             ],
         }
 
-        return {k: v for k, v in fields.items() if bool(v)}
+        return {k: v for k, v in fields.items() if v not in OPTIONAL_FIELD_VALUES_TO_OMIT}
 
     def type_info(self) -> TypeConstraintExpression:
         if self.is_array_type():

--- a/tools/data-model-exporter/data_model_exporter/property_types.py
+++ b/tools/data-model-exporter/data_model_exporter/property_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .typing import SingleTypeConstraint
+from data_model_exporter.typing import SingleTypeConstraint
 
 
 @dataclass

--- a/tools/data-model-exporter/data_model_exporter/property_types.py
+++ b/tools/data-model-exporter/data_model_exporter/property_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .typing import TypeEntry
+from .typing import SingleTypeConstraint
 
 
 @dataclass
@@ -9,10 +9,10 @@ class TypeAnnotation:
 
 
 class PrimitiveType(TypeAnnotation):
-    def type_entry(self) -> TypeEntry:
+    def type_constraint_dict(self) -> SingleTypeConstraint:
         return {'type': self.name}
 
 
 class RefType(TypeAnnotation):
-    def type_entry(self) -> TypeEntry:
+    def type_constraint_dict(self) -> SingleTypeConstraint:
         return {'$ref': self.name}

--- a/tools/data-model-exporter/data_model_exporter/property_types.py
+++ b/tools/data-model-exporter/data_model_exporter/property_types.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from .typing import TypeEntry
+
+
+@dataclass
+class TypeAnnotation:
+    name: str
+
+
+class PrimitiveType(TypeAnnotation):
+    def type_entry(self) -> TypeEntry:
+        return {'type': self.name}
+
+
+class RefType(TypeAnnotation):
+    def type_entry(self) -> TypeEntry:
+        return {'$ref': self.name}

--- a/tools/data-model-exporter/data_model_exporter/property_types.py
+++ b/tools/data-model-exporter/data_model_exporter/property_types.py
@@ -1,3 +1,6 @@
+"""
+different kinds of type annotation for properties
+"""
 from dataclasses import dataclass
 
 from data_model_exporter.typing import SingleTypeConstraint

--- a/tools/data-model-exporter/data_model_exporter/rdf_graph_manager.py
+++ b/tools/data-model-exporter/data_model_exporter/rdf_graph_manager.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+from cached_property import cached_property
+import rdflib
+from rdflib import Graph, Namespace
+
+from .property_types import PrimitiveType, RefType
+from .typing import PropertyType, RdfNodeName
+
+PRIMITIVE_TYPES = {
+    'xsd:string': 'string',
+    'xsd:anyURI': 'string',
+}
+
+
+# helper functions to perform common translations between RDF graphs and our data model
+@dataclass
+class RdfGraphManager:
+    graph: Graph
+
+    def namespaced_name_for_node(self, node: rdflib.term.Identifier) -> RdfNodeName:
+        name: str = node.n3(self.graph.namespace_manager)  # hardcoding type for type annotations
+        return RdfNodeName(name)
+
+    def type_annotation_to_property_type(self, node: rdflib.term.Identifier) -> PropertyType:
+        if isinstance(node, rdflib.term.URIRef):
+            namespaced_name = self.namespaced_name_for_node(node)
+            if namespaced_name in PRIMITIVE_TYPES:
+                return PrimitiveType(PRIMITIVE_TYPES[namespaced_name])
+
+            return RefType(namespaced_name)
+
+        raise ValueError(f"Unrecognized type annotation {node}")
+
+    @cached_property
+    def primary_namespace(self) -> Namespace:
+        # primary namespace for a graph is listed both under its actual namespace
+        # and under the 'empty string' namespace
+        namespace_uriref = dict([namespace for namespace in self.graph.namespaces()])['']
+
+        return Namespace(str(namespace_uriref))

--- a/tools/data-model-exporter/data_model_exporter/rdf_graph_manager.py
+++ b/tools/data-model-exporter/data_model_exporter/rdf_graph_manager.py
@@ -1,3 +1,6 @@
+"""
+a service object containing functions to perform common translations between RDF graphs and our data model
+"""
 from dataclasses import dataclass
 
 from cached_property import cached_property
@@ -13,7 +16,6 @@ PRIMITIVE_TYPES = {
 }
 
 
-# helper functions to perform common translations between RDF graphs and our data model
 @dataclass
 class RdfGraphManager:
     graph: Graph

--- a/tools/data-model-exporter/data_model_exporter/rdf_graph_manager.py
+++ b/tools/data-model-exporter/data_model_exporter/rdf_graph_manager.py
@@ -4,8 +4,8 @@ from cached_property import cached_property
 import rdflib
 from rdflib import Graph, Namespace
 
-from .property_types import PrimitiveType, RefType
-from .typing import PropertyType, RdfNodeName
+from data_model_exporter.property_types import PrimitiveType, RefType
+from data_model_exporter.typing import PropertyType, RdfNodeName
 
 PRIMITIVE_TYPES = {
     'xsd:string': 'string',

--- a/tools/data-model-exporter/data_model_exporter/schema.py
+++ b/tools/data-model-exporter/data_model_exporter/schema.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass, field
 import logging
 from typing import Any, Optional
 
-from .property import Property
-from .typing import JsonSchema, RdfNodeName
+from data_model_exporter.common import OPTIONAL_FIELD_VALUES_TO_OMIT
+from data_model_exporter.property import Property
+from data_model_exporter.typing import JsonSchema, RdfNodeName
 
 
 @dataclass
@@ -30,7 +31,7 @@ class Schema:
             'skos:altLabel': self.skos_altlabels,
         }
 
-        return {k: v for k, v in fields.items() if bool(v)}
+        return {k: v for k, v in fields.items() if v not in OPTIONAL_FIELD_VALUES_TO_OMIT}
 
     def set_description(self, new_description: str, source: RdfNodeName) -> None:
         if self.description_already_set_by == 'skos:definition':

--- a/tools/data-model-exporter/data_model_exporter/schema.py
+++ b/tools/data-model-exporter/data_model_exporter/schema.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .property import Property
+from .typing import JsonSchema
+
+
+@dataclass
+class Schema:
+    term: str
+    description: str = ""
+    title: Optional[str] = None
+    skos_preflabel: Optional[str] = None
+    skos_altlabels: list[str] = field(default_factory=list)
+    equivalent_class: list[str] = field(default_factory=list)
+    subclass_of: list[str] = field(default_factory=list)
+    exact_synonym: list[str] = field(default_factory=list)
+    properties: dict[str, Property] = field(default_factory=dict)
+
+    def optional_fields(self) -> dict[str, Any]:
+        fields = {
+            'title': self.title,
+            'owl:equivalentClass': self.equivalent_class,
+            'skos:exactMatch': self.exact_synonym,
+            'rdfs:subClassOf': self.subclass_of,
+            'skos:prefLabel': self.skos_preflabel,
+            'skos:altLabel': self.skos_altlabels,
+        }
+
+        return {k: v for k, v in fields.items() if bool(v)}
+
+    def as_dict(self) -> JsonSchema:
+        base_info = {
+            '$id': self.term,
+            'description': self.description,
+            '$schema': "http://json-schema.org/draft-07/schema#/",
+            'definitions': {},
+            'type': 'object',
+            'additionalProperties': any(self.properties),
+            'properties': {
+                name: prop.as_dict()
+                for name, prop
+                in self.properties.items()
+            },
+            'required': self.required_property_names(),
+            **self.optional_fields(),
+        }
+
+        return base_info
+
+    def required_property_names(self) -> list[str]:
+        return [
+            prop.name
+            for prop
+            in self.properties.values()
+            if prop.required
+        ]

--- a/tools/data-model-exporter/data_model_exporter/schema.py
+++ b/tools/data-model-exporter/data_model_exporter/schema.py
@@ -1,3 +1,7 @@
+"""
+Intermediate representation for a class in a TTL schema, including
+logic to serialize to JSON schema
+"""
 from dataclasses import dataclass, field
 import logging
 from typing import Any, Optional

--- a/tools/data-model-exporter/data_model_exporter/tests/fixtures/test.ttl
+++ b/tools/data-model-exporter/data_model_exporter/tests/fixtures/test.ttl
@@ -1,0 +1,89 @@
+# baseURI: https://zombo.com/zombo
+# imports: http://www.w3.org/ns/dcat
+# prefix: zombo
+
+@prefix : <https://zombo.com/zombo#> .
+@prefix zombo: <https://zombo.com/zombo#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix duo: <http://purl.obolibrary.org/obo/duo-basic.owl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://zombo.com/zombo>
+  a owl:Ontology ;
+  rdfs:comment "This is Zombocom." ;
+  owl:imports <http://www.w3.org/ns/dcat> ;
+  owl:versionInfo "Welcome to Zombocom." ;
+.
+zombo:Zombocom
+  a rdfs:Class ;
+  rdfs:label "ZomboLabel" ;
+  skos:prefLabel "ZomboPrefLabel" ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty zombo:possibilities ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom zombo:Possibility ;
+      owl:onProperty zombo:possibilities ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:someValuesFrom xsd:string ;
+      owl:onProperty zombo:redundancy ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom zombo:Yourself ;
+      owl:onProperty zombo:limit ;
+    ] ;
+  owl:equivalentClass [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty zombo:limit ;
+    ] ;
+  prov:definition "This is Zombocom."
+.
+zombo:Possibility
+  a rdfs:Class ;
+  rdfs:label "Possibility" ;
+  prov:definition "You can do anything at Zombocom." ;
+.
+zombo:redundancy
+  a owl:ObjectProperty ;
+  rdfs:domain zombo:Zombocom ;
+  skos:definition "Yes, this is Zombocom." ;
+  prov:definition "Welcome to Zombocom." ;
+  skos:prefLabel "This" ;
+.
+zombo:greeting
+  a owl:Property ;
+  rdfs:domain zombo:Zombocom ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "Welcome to Zombocom."
+          "This is Zombocom."
+        ) ;
+    ] ;
+.
+zombo:abilityToDoAnything
+  a owl:Property ;
+  rdfs:domain zombo:Yourself ;
+.
+zombo:limit
+  a owl:ObjectProperty ;
+  rdfs:domain zombo:Zombocom ;
+  skos:prefLabel "Limit" ;
+.
+zombo:Yourself
+  a rdfs:Class ;
+  skos:definition "The only limit is yourself." ;
+.

--- a/tools/data-model-exporter/data_model_exporter/tests/test_nothing.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_nothing.py
@@ -1,7 +1,0 @@
-import unittest
-
-
-# empty test case to assure pytest that our test suite is set up correctly.
-class DummyTestCase(unittest.TestCase):
-    def test_nothing(self):
-        print("hooray")

--- a/tools/data-model-exporter/data_model_exporter/tests/test_property.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_property.py
@@ -1,56 +1,121 @@
 import unittest
 
 from data_model_exporter.property import Property
+from data_model_exporter.property_types import PrimitiveType, RefType
 
 
 class PropertyTestCase(unittest.TestCase):
     def test_is_array_type_true_if_either_cardinality(self):
         self.assertTrue(Property("foo", "desc", min_cardinality=1).is_array_type())
+        self.assertTrue(Property("foo", "desc", max_cardinality=3).is_array_type())
 
     def test_is_array_type_false_if_neither_cardinality(self):
         self.assertFalse(Property("foo", "desc").is_array_type())
 
     def test_add_type_adds_type(self):
-        pass
+        prop = Property("foo", "desc")
+        self.assertEqual(len(prop.allowed_types), 0)
+        prop.add_type(PrimitiveType("string"))
+        self.assertEqual(prop.allowed_types, [PrimitiveType("string")])
 
     def test_add_type_blocks_further_types_if_restrictive(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(PrimitiveType("string"), restrictive=True)
+        with self.assertRaises(ValueError):
+            prop.add_type(RefType("argbl"))
 
     def test_add_type_allows_further_types_if_not_restrictive(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(PrimitiveType("string"), restrictive=False)
+        # we just run this to see if it raises an exception, so there's no assertions in the test
+        prop.add_type(RefType("argbl"))
 
     def test_add_type_mutex_with_allowed_values(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(PrimitiveType("string"))
+        with self.assertRaises(ValueError):
+            prop.add_enum_value("steve")
 
     def test_add_type_ignores_duplicates(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(PrimitiveType("string"))
+        prop.add_type(PrimitiveType("string"))
+        self.assertEqual(prop.allowed_types, [PrimitiveType("string")])
 
     def test_add_enum_value_adds_enum_value(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_enum_value("steve")
+        self.assertEqual(prop.allowed_values, ["steve"])
 
     def test_add_enum_value_mutex_with_type_constraints(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_enum_value("steve")
+        with self.assertRaises(ValueError):
+            prop.add_type(PrimitiveType("string"))
 
     def test_optional_fields_includes_only_defined_fields(self):
-        pass
+        prop = Property(
+            "foo",
+            "desc",
+            comment="hey",
+            skos_preflabel="jimbo"
+        )
+
+        optional_fields = prop.optional_fields()
+        self.assertIn("comment", optional_fields)
+        self.assertIn("skos:prefLabel", optional_fields)
+        self.assertNotIn("title", optional_fields)
+        self.assertNotIn("oneOf", optional_fields)
 
     def test_base_type_info_defaults_to_string(self):
-        pass
+        prop = Property("foo", "desc")
+        self.assertEqual(prop.base_type_info(), {'type': 'string'})
 
     def test_base_type_info_returns_type_for_single_value(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(RefType("reef"))
+        self.assertEqual(prop.base_type_info(), {'$ref': 'reef'})
 
     def test_base_type_info_returns_oneof_for_multiple_values(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(RefType("ref1"))
+        prop.add_type(RefType("ref2"))
+        self.assertEqual(prop.base_type_info(), {
+            'oneOf': [
+                {'$ref': 'ref1'},
+                {'$ref': 'ref2'},
+            ]
+        })
 
     def test_type_info_generates_flat_type_info_if_not_array(self):
-        pass
+        prop = Property("foo", "desc")
+        prop.add_type(RefType("reef"))
+        self.assertEqual(prop.type_info(), {'$ref': 'reef'})
 
     def test_type_info_wraps_in_array_if_array(self):
-        pass
+        prop = Property("foo", "desc", min_cardinality=0)
+        prop.add_type(RefType("reef"))
+        self.assertEqual(prop.type_info(), {
+            'type': 'array',
+            'items': {'$ref': 'reef'},
+        })
 
     def test_as_dict_includes_expected_fields(self):
-        pass
+        prop = Property("foo", "desc", max_cardinality=3)
+        prop.add_enum_value("steve")
+        prop.add_enum_value("stove")
+        expected_fields = {
+            'description': 'desc',
+            'oneOf': ['steve', 'stove'],
+            'type': 'array',
+            'items': {'type': 'string'},
+            'maxItems': 3,
+        }
+        dictified = prop.as_dict()
+        for expected_field, expected_value in expected_fields.items():
+            self.assertIn(expected_field, dictified)
+            self.assertEqual(dictified[expected_field], expected_value)
 
     def test_as_dict_always_includes_description_even_if_blank(self):
-        pass
+        prop = Property("foo", "", max_cardinality=3)
+        self.assertIn('description', prop.as_dict())

--- a/tools/data-model-exporter/data_model_exporter/tests/test_property.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_property.py
@@ -1,0 +1,56 @@
+import unittest
+
+from data_model_exporter.property import Property
+
+
+class PropertyTestCase(unittest.TestCase):
+    def test_is_array_type_true_if_either_cardinality(self):
+        self.assertTrue(Property("foo", "desc", min_cardinality=1).is_array_type())
+
+    def test_is_array_type_false_if_neither_cardinality(self):
+        self.assertFalse(Property("foo", "desc").is_array_type())
+
+    def test_add_type_adds_type(self):
+        pass
+
+    def test_add_type_blocks_further_types_if_restrictive(self):
+        pass
+
+    def test_add_type_allows_further_types_if_not_restrictive(self):
+        pass
+
+    def test_add_type_mutex_with_allowed_values(self):
+        pass
+
+    def test_add_type_ignores_duplicates(self):
+        pass
+
+    def test_add_enum_value_adds_enum_value(self):
+        pass
+
+    def test_add_enum_value_mutex_with_type_constraints(self):
+        pass
+
+    def test_optional_fields_includes_only_defined_fields(self):
+        pass
+
+    def test_base_type_info_defaults_to_string(self):
+        pass
+
+    def test_base_type_info_returns_type_for_single_value(self):
+        pass
+
+    def test_base_type_info_returns_oneof_for_multiple_values(self):
+        pass
+
+    def test_type_info_generates_flat_type_info_if_not_array(self):
+        pass
+
+    def test_type_info_wraps_in_array_if_array(self):
+        pass
+
+    def test_as_dict_includes_expected_fields(self):
+        pass
+
+    def test_as_dict_always_includes_description_even_if_blank(self):
+        pass

--- a/tools/data-model-exporter/data_model_exporter/tests/test_rdf_graph_manager.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_rdf_graph_manager.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+from rdflib import Graph
+
+from data_model_exporter.rdf_graph_manager import RdfGraphManager
+
+
+class RdfGraphManagerTestCase(unittest.TestCase):
+    def fixture_path(self, filename):
+        return os.path.join(os.path.dirname(__file__), 'fixtures', filename)
+
+    def setUp(self):
+        # parse in the graph in the ttl file
+        with open(self.fixture_path('test.ttl'), 'r') as ttl_file:
+            self.graph = Graph().parse(ttl_file, format='turtle')
+        self.graph_manager = RdfGraphManager(self.graph)
+
+    def test_primary_namespace_detects_correct_namespace(self):
+        self.assertEqual('https://zombo.com/zombo#', str(self.graph_manager.primary_namespace))

--- a/tools/data-model-exporter/data_model_exporter/tests/test_schema.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_schema.py
@@ -1,17 +1,66 @@
 import unittest
 
+from data_model_exporter.property import Property
 from data_model_exporter.schema import Schema
 
 
 class SchemaTestCase(unittest.TestCase):
     def test_optional_fields_includes_only_defined_fields(self):
-        pass
+        schema = Schema(
+            "term_name",
+            skos_preflabel="preferred",
+            exact_synonym=["splynonym"])
+
+        fields = schema.optional_fields()
+        self.assertIn('skos:prefLabel', fields)
+        self.assertIn('skos:exactMatch', fields)
+        self.assertNotIn('title', fields)
+        self.assertNotIn('owl:equivalentClass', fields)
+        self.assertNotIn('rdfs:subClassOf', fields)
 
     def test_required_property_names_includes_only_required_properties(self):
-        pass
+        schema = Schema(
+            "term_name",
+            properties={
+                'mandatory': Property('mandatory', 'desc', required=True),
+                'whatever_man': Property('whatever_man', 'desc', required=False),
+            }
+        )
+
+        self.assertEqual(schema.required_property_names(), ['mandatory'])
 
     def test_as_dict_includes_expected_fields(self):
-        pass
+        schema = Schema(
+            "term_name",
+            properties={
+                'mandatory': Property('mandatory', 'desc', required=True),
+                'whatever_man': Property('whatever_man', 'desc', required=False),
+            },
+            skos_preflabel="preferred",
+            exact_synonym=["splynonym"])
+
+        expected_fields = {
+            '$id': 'term_name',
+            'type': 'object',
+            'additionalProperties': True,
+            'properties': {
+                'mandatory': {
+                    'description': 'desc',
+                    'type': 'string'
+                },
+                'whatever_man': {
+                    'description': 'desc',
+                    'type': 'string'
+                },
+            },
+            'required': ['mandatory']
+        }
+        schema_dict = schema.as_dict()
+
+        for expected_field, expected_value in expected_fields.items():
+            self.assertIn(expected_field, schema_dict)
+            self.assertEqual(schema_dict[expected_field], expected_value)
 
     def test_as_dict_always_includes_description_even_if_blank(self):
-        pass
+        schema = Schema("term", description="")
+        self.assertIn("description", schema.as_dict())

--- a/tools/data-model-exporter/data_model_exporter/tests/test_schema.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_schema.py
@@ -1,0 +1,17 @@
+import unittest
+
+from data_model_exporter.schema import Schema
+
+
+class SchemaTestCase(unittest.TestCase):
+    def test_optional_fields_includes_only_defined_fields(self):
+        pass
+
+    def test_required_property_names_includes_only_required_properties(self):
+        pass
+
+    def test_as_dict_includes_expected_fields(self):
+        pass
+
+    def test_as_dict_always_includes_description_even_if_blank(self):
+        pass

--- a/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
@@ -16,9 +16,6 @@ class TtlSchemaGeneratorTestCase(unittest.TestCase):
         self.generator = TtlSchemaGenerator('Zombocom', self.fixture_path('test.ttl'))
         self.generator.build_schema()
 
-    def test_primary_namespace_detects_correct_namespace(self):
-        self.assertEqual('https://zombo.com/zombo#', str(self.generator.primary_namespace))
-
     def test_ensure_property_initialized_is_idempotent_and_initializes_property(self):
         zombo_node = rdflib.term.URIRef("https://zombo.com/zombo#possibilities")
         self.generator.ensure_property_initialized(zombo_node)

--- a/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
@@ -1,41 +1,74 @@
+import copy
+import os
 import unittest
 
+import rdflib
+
 from data_model_exporter.ttl_schema_generator import TtlSchemaGenerator
+from data_model_exporter.property_types import PrimitiveType, RefType
 
 
 class TtlSchemaGeneratorTestCase(unittest.TestCase):
+    def fixture_path(self, filename):
+        return os.path.join(os.path.dirname(__file__), 'fixtures', filename)
+
+    def setUp(self):
+        self.generator = TtlSchemaGenerator('Zombocom', self.fixture_path('test.ttl'))
+        self.generator.build_schema()
+
     def test_primary_namespace_detects_correct_namespace(self):
-        pass
+        self.assertEqual('https://zombo.com/zombo#', str(self.generator.primary_namespace))
 
     def test_ensure_property_initialized_is_idempotent_and_initializes_property(self):
-        pass
+        zombo_node = rdflib.term.URIRef("https://zombo.com/zombo#possibilities")
+        self.generator.ensure_property_initialized(zombo_node)
+        self.assertIn("zombo:possibilities", self.generator.schema.properties)
+        first_execution = copy.deepcopy(self.generator.schema.properties['zombo:possibilities'])
+        self.generator.ensure_property_initialized(zombo_node)
+        self.assertEqual(first_execution, self.generator.schema.properties['zombo:possibilities'])
 
     def test_annotates_schema_with_various_flat_fields(self):
-        pass
-
-    def test_annotates_from_restriction_properties(self):
-        pass
-
-    def test_annotates_property_with_various_flat_fields(self):
-        pass
+        self.assertEqual(self.generator.schema.description, "This is Zombocom.")
+        self.assertEqual(self.generator.schema.title, "ZomboLabel")
+        self.assertEqual(self.generator.schema.skos_preflabel, "ZomboPrefLabel")
 
     def test_annotates_from_domain_fields(self):
-        pass
+        self.assertIn('zombo:redundancy', self.generator.schema.properties)
+        this_is_zombocom = self.generator.schema.properties['zombo:redundancy']
+        self.assertEqual(this_is_zombocom.description, "Yes, this is Zombocom.")
 
     def test_annotates_enumerated_ranges_on_property(self):
-        pass
+        self.assertIn('zombo:greeting', self.generator.schema.properties)
+        enum_values = self.generator.schema.properties['zombo:greeting'].allowed_values
+        self.assertEqual(enum_values, [
+            "Welcome to Zombocom.",
+            "This is Zombocom."
+        ])
 
-    def test_annotates_various_ref_fields(self):
-        pass
+    def test_does_not_annotate_properties_on_other_classes(self):
+        self.assertNotIn('zombo:abilityToDoAnything', self.generator.schema.properties)
 
     def test_annotates_one_cardinality_as_required(self):
-        pass
+        self.assertIn('zombo:limit', self.generator.schema.properties)
+        the_only_limit = self.generator.schema.properties['zombo:limit']
+        self.assertTrue(the_only_limit.required)
 
-    def test_annotates_somevaluesfrom_as_oneof(self):
-        pass
+    def test_annotates_somevaluesfrom_as_array(self):
+        self.assertIn('zombo:redundancy', self.generator.schema.properties)
+        this_is_zombocom = self.generator.schema.properties['zombo:redundancy']
+        self.assertEqual(this_is_zombocom.allowed_types, [PrimitiveType('string')])
+        redundancy_dict = this_is_zombocom.as_dict()
+        self.assertEqual(redundancy_dict['type'], 'array')
+        self.assertEqual(redundancy_dict['items'], {'type':  'string'})
 
     def test_annotates_allvaluesfrom_as_type(self):
-        pass
+        self.assertIn('zombo:limit', self.generator.schema.properties)
+        the_only_limit = self.generator.schema.properties['zombo:limit']
+        self.assertEqual(the_only_limit.allowed_types, [RefType('zombo:Yourself')])
+        self.assertEqual(the_only_limit.as_dict()['$ref'], 'zombo:Yourself')
 
     def test_annotates_cardinality_limits_as_array_type(self):
-        pass
+        self.assertIn('zombo:possibilities', self.generator.schema.properties)
+        infinite_possibilities = self.generator.schema.properties['zombo:possibilities']
+        self.assertEqual(infinite_possibilities.min_cardinality, 1)
+        self.assertTrue(infinite_possibilities.is_array_type())

--- a/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
@@ -59,7 +59,7 @@ class TtlSchemaGeneratorTestCase(unittest.TestCase):
         self.assertEqual(this_is_zombocom.allowed_types, [PrimitiveType('string')])
         redundancy_dict = this_is_zombocom.as_dict()
         self.assertEqual(redundancy_dict['type'], 'array')
-        self.assertEqual(redundancy_dict['items'], {'type':  'string'})
+        self.assertEqual(redundancy_dict['items'], {'type': 'string'})
 
     def test_annotates_allvaluesfrom_as_type(self):
         self.assertIn('zombo:limit', self.generator.schema.properties)

--- a/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/tests/test_ttl_schema_generator.py
@@ -1,0 +1,41 @@
+import unittest
+
+from data_model_exporter.ttl_schema_generator import TtlSchemaGenerator
+
+
+class TtlSchemaGeneratorTestCase(unittest.TestCase):
+    def test_primary_namespace_detects_correct_namespace(self):
+        pass
+
+    def test_ensure_property_initialized_is_idempotent_and_initializes_property(self):
+        pass
+
+    def test_annotates_schema_with_various_flat_fields(self):
+        pass
+
+    def test_annotates_from_restriction_properties(self):
+        pass
+
+    def test_annotates_property_with_various_flat_fields(self):
+        pass
+
+    def test_annotates_from_domain_fields(self):
+        pass
+
+    def test_annotates_enumerated_ranges_on_property(self):
+        pass
+
+    def test_annotates_various_ref_fields(self):
+        pass
+
+    def test_annotates_one_cardinality_as_required(self):
+        pass
+
+    def test_annotates_somevaluesfrom_as_oneof(self):
+        pass
+
+    def test_annotates_allvaluesfrom_as_type(self):
+        pass
+
+    def test_annotates_cardinality_limits_as_array_type(self):
+        pass

--- a/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
@@ -5,11 +5,11 @@ import rdflib
 from rdflib import Graph, Namespace, RDF, RDFS, OWL, SKOS
 from rdflib.collection import Collection
 
-from .rdf_graph_manager import RdfGraphManager
-from .schema import Schema
-from .property import Property
-from .property_types import RefType
-from .typing import JsonSchema
+from data_model_exporter.rdf_graph_manager import RdfGraphManager
+from data_model_exporter.schema import Schema
+from data_model_exporter.property import Property
+from data_model_exporter.property_types import RefType
+from data_model_exporter.typing import JsonSchema
 
 # we manually define this because the preinstalled PROV namespace in rdflib doesn't include some terms we use,
 # e.g. 'definition'

--- a/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
@@ -9,7 +9,7 @@ from rdflib.collection import Collection
 from .schema import Schema
 from .property import Property
 from .property_types import PrimitiveType, RefType
-from .typing import JsonSchema, PropertyType
+from .typing import JsonSchema, PropertyType, RdfNodeName
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -76,7 +76,7 @@ class TtlSchemaGenerator:
     def _annotate_by_class_namespace(self) -> None:
         for predicate, ttl_object in self.graph.predicate_objects(self.term):
             if predicate in [PROV.definition, SKOS.definition]:
-                self.schema.description = ttl_object.value
+                self.schema.set_description(ttl_object.value, self.namespaced_name_for_node(predicate))
             elif predicate == RDFS.label:
                 self.schema.title = ttl_object.value
             elif predicate == SKOS.prefLabel:
@@ -166,9 +166,9 @@ class TtlSchemaGenerator:
         if property_name not in self.schema.properties:
             self.schema.properties[property_name] = Property(property_name, str(target_property))
 
-    def namespaced_name_for_node(self, node: rdflib.term.Identifier) -> str:
+    def namespaced_name_for_node(self, node: rdflib.term.Identifier) -> RdfNodeName:
         name: str = node.n3(self.graph.namespace_manager)  # hardcoding type for type annotations
-        return name
+        return RdfNodeName(name)
 
     def _annotate_blank_node(self, predicate: rdflib.term.Identifier, ttl_object: rdflib.term.Identifier) -> None:
         if self.graph.value(ttl_object, RDF.type) != OWL.Restriction:

--- a/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
@@ -1,0 +1,214 @@
+from dataclasses import dataclass, field
+import logging
+
+from cached_property import cached_property
+import rdflib
+from rdflib import Graph, Namespace, RDF, RDFS, OWL, SKOS
+from rdflib.collection import Collection
+
+from .schema import Schema
+from .property import Property
+from .property_types import PrimitiveType, RefType
+from .typing import JsonSchema, PropertyType
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+# we manually define this because the preinstalled namespace in rdflib doesn't include some terms we use,
+# e.g. 'definition'
+PROV = Namespace("http://www.w3.org/ns/prov#")
+OBO_IN_OWL = Namespace("http://www.geneontology.org/formats/oboInOwl#")
+
+PRIMITIVE_TYPES = {
+    'xsd:string': 'string',
+    'xsd:anyURI': 'string',
+}
+
+# properties that should appear in the json schema even if they aren't present in the ttl file
+UNIVERSAL_PROPERTIES = {
+    'rdfs:label': Property('rdfs:label', "A human-readable name for the entity."),
+    'id': Property('id', "UUID for this entity."),
+    'describedBy': Property('describedBy', "The URL reference to the JSON Schema that defines this object."),
+}
+
+SKIPPABLE_DOMAIN_PREDICATES = [
+    RDF.type,     # this just indicates something is a property, which we already know
+    RDFS.domain,  # no point annotating domain, since it's how we get a list of props for a class to begin with
+]
+
+SKIPPABLE_RESTRICTION_PREDICATES = [
+    RDF.type,        # indicates that it's a restriction property. we check this explicitly before scanning.
+    OWL.onProperty,  # we grab this beforehand as well to see what property the restrictions apply to.
+]
+
+
+@dataclass
+class TtlSchemaGenerator:
+    class_name: str
+    ttl_file_path: str
+
+    schema: Schema = field(init=False)
+
+    def __post_init__(self) -> None:
+        # parse in the graph in the ttl file
+        with open(self.ttl_file_path, 'r') as ttl_file:
+            self.graph = Graph().parse(ttl_file, format='turtle')
+
+        # note down the class we're analyzing
+        self.term = self.primary_namespace.term(self.class_name)
+
+        # set up the skeleton of the schema
+        self.schema = Schema(self.term)
+        self.schema.properties.update(UNIVERSAL_PROPERTIES)
+
+    @cached_property
+    def primary_namespace(self) -> Namespace:
+        # primary namespace for a graph is listed both under its actual namespace and under the 'empty string' namespace
+        namespace_uriref = dict([namespace for namespace in self.graph.namespaces()])['']
+
+        return Namespace(str(namespace_uriref))
+
+    def build_schema(self) -> JsonSchema:
+        self._annotate_by_class_namespace()
+        self._annotate_by_domain()
+
+        return self.schema.as_dict()
+
+    def _annotate_by_class_namespace(self) -> None:
+        for predicate, ttl_object in self.graph.predicate_objects(self.term):
+            if predicate in [PROV.definition, SKOS.definition]:
+                self.schema.description = ttl_object.value
+            elif predicate == RDFS.label:
+                self.schema.title = ttl_object.value
+            elif predicate == SKOS.prefLabel:
+                self.schema.skos_preflabel = ttl_object.value
+            elif predicate == SKOS.altLabel:
+                self.schema.skos_altlabels.append(ttl_object.value)
+            elif predicate in [OBO_IN_OWL.hasExactSynonym, SKOS.exactMatch]:
+                self.schema.exact_synonym.append(ttl_object.value)
+            elif predicate == OWL.equivalentClass:
+                if isinstance(ttl_object, rdflib.term.BNode):
+                    self._annotate_blank_node(predicate, ttl_object)
+                elif isinstance(ttl_object, rdflib.term.URIRef):
+                    self.schema.equivalent_class.append(self.namespaced_name_for_node(ttl_object))
+                else:
+                    logging.warning(
+                        f"Unrecognized object type for owl:equivalentClass {ttl_object} under {self.term}, skipping.")
+            elif predicate == RDFS.subClassOf:
+                if isinstance(ttl_object, rdflib.term.BNode):
+                    self._annotate_blank_node(predicate, ttl_object)
+                elif isinstance(ttl_object, rdflib.term.URIRef):
+                    self.schema.subclass_of.append(self.namespaced_name_for_node(ttl_object))
+                else:
+                    logging.warning(
+                        f"Unrecognized object type for rdfs:subClassOf {ttl_object} under {self.term}, skipping.")
+            else:
+                logging.warning(f"Unknown schema-level predicate {predicate} for {self.term}, skipping.")
+
+    def type_annotation_to_property_type(self, node: rdflib.term.Identifier) -> PropertyType:
+        if isinstance(node, rdflib.term.URIRef):
+            namespaced_name = self.namespaced_name_for_node(node)
+            if namespaced_name in PRIMITIVE_TYPES:
+                return PrimitiveType(PRIMITIVE_TYPES[namespaced_name])
+
+            return RefType(namespaced_name)
+
+        raise ValueError(f"Unrecognized type annotation {node}")
+
+    def _annotate_by_domain(self) -> None:
+        # look up all property definitions under this class's domain
+        for term_property in self.graph.subjects(RDFS.domain, self.term):
+            self.ensure_property_initialized(term_property)
+
+            property_name = self.namespaced_name_for_node(term_property)
+
+            # grab all fields under the property definition
+            for predicate, ttl_object in self.graph.predicate_objects(term_property):
+                if predicate in SKIPPABLE_DOMAIN_PREDICATES:
+                    continue
+
+                if predicate == RDFS.range:
+                    if isinstance(ttl_object, rdflib.term.BNode):
+                        # happens in ranges occasionally
+                        if self.graph.value(ttl_object, RDF.type) != RDFS.Datatype:
+                            raise ValueError("Attempted to parse non-datatype BNode as type annotation")
+                        for bnode_predicate, bnode_object in self.graph.predicate_objects(ttl_object):
+                            if bnode_predicate == RDF.type:
+                                continue
+
+                            if bnode_predicate == OWL.oneOf:
+                                # it's listing a collection of types, so we yank 'em all out
+                                types_collection = Collection(self.graph, bnode_object)
+                                for type_annotation in types_collection:
+                                    self.schema.properties[property_name].allowed_values.append(type_annotation.value)
+                            else:
+                                logging.warning(f"Skipping field {bnode_predicate} in inner BNode of {property_name}")
+                    # self.schema.properties[property_name].add_type(self.type_annotation_to_property_type(ttl_object))
+                elif predicate == RDFS.label:
+                    self.schema.properties[property_name].title = ttl_object.value
+                elif predicate == RDFS.comment:
+                    self.schema.properties[property_name].comment = ttl_object.value
+                elif predicate == SKOS.prefLabel:
+                    self.schema.properties[property_name].skos_preflabel = ttl_object.value
+                elif predicate == SKOS.definition:
+                    self.schema.properties[property_name].description = ttl_object.value
+                elif predicate == RDFS.subPropertyOf:
+                    self.schema.properties[property_name].parent_properties.append(
+                        RefType(self.namespaced_name_for_node(ttl_object))
+                    )
+                else:
+                    logging.warning(
+                        f"Skipping domain-level property field {predicate} with value {ttl_object} "
+                        f" for {property_name}."
+                    )
+
+    def ensure_property_initialized(self, target_property: rdflib.term.Identifier) -> None:
+        property_name = target_property.n3(self.graph.namespace_manager)
+        if property_name not in self.schema.properties:
+            self.schema.properties[property_name] = Property(property_name, str(target_property))
+
+    def namespaced_name_for_node(self, node: rdflib.term.Identifier) -> str:
+        name: str = node.n3(self.graph.namespace_manager)  # hardcoding type for type annotations
+        return name
+
+    def _annotate_blank_node(self, predicate: rdflib.term.Identifier, ttl_object: rdflib.term.Identifier) -> None:
+        if self.graph.value(ttl_object, RDF.type) != OWL.Restriction:
+            raise ValueError("Tried to process a blank node that isn't a restriction property.")
+
+        # annotating a property means there's at least one additional property
+        target_property = self.graph.value(ttl_object, OWL.onProperty)
+        namespaced_target_name = self.namespaced_name_for_node(target_property)
+
+        self.ensure_property_initialized(target_property)
+
+        for predicate, ttl_object in self.graph.predicate_objects(ttl_object):
+            if predicate in SKIPPABLE_RESTRICTION_PREDICATES:
+                continue
+
+            if predicate == OWL.cardinality:
+                if ttl_object.value == 1:
+                    self.schema.properties[namespaced_target_name].required = True
+                else:
+                    logging.error(
+                        f"Found non-one cardinality for property {namespaced_target_name} ({ttl_object.value}), ignoring"
+                    )
+
+            elif predicate == OWL.minCardinality:
+                self.schema.properties[namespaced_target_name].min_cardinality = ttl_object.value
+
+            elif predicate == OWL.maxCardinality:
+                self.schema.properties[namespaced_target_name].max_cardinality = ttl_object.value
+
+            elif predicate == OWL.allValuesFrom:
+                self.schema.properties[namespaced_target_name].add_type(
+                    self.type_annotation_to_property_type(ttl_object),
+                    restrictive=True,
+                )
+
+            elif predicate == OWL.someValuesFrom:
+                self.schema.properties[namespaced_target_name].min_cardinality = 0
+                self.schema.properties[namespaced_target_name].add_type(
+                    self.type_annotation_to_property_type(ttl_object),
+                    restrictive=False,
+                )
+            else:
+                logging.warning(f"Skipping restriction property field {predicate} with value {ttl_object}.")

--- a/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
+++ b/tools/data-model-exporter/data_model_exporter/ttl_schema_generator.py
@@ -1,3 +1,7 @@
+"""
+tool that scans a TTL schema file's information for a given class,
+transforming it into our intermediate data model (Schema with many Propertys)
+"""
 from dataclasses import dataclass, field
 import logging
 

--- a/tools/data-model-exporter/data_model_exporter/typing.py
+++ b/tools/data-model-exporter/data_model_exporter/typing.py
@@ -5,35 +5,44 @@ JsonSchema = dict[str, Any]
 # a type annotation is either:
 #  * a reference type (e.g. {"$ref": "some:thing"})
 #  * a primitive type (e.g. {"type": "string"})
+RefTypeConstraint = TypedDict('RefTypeConstraint', {'$ref': str})
+PrimitiveTypeConstraint = TypedDict('PrimitiveTypeConstraint', {'type': str})
 
-RefTypeEntry = TypedDict('RefTypeEntry', {'$ref': str})
-PrimitiveTypeEntry = TypedDict('PrimitiveTypeEntry', {'type': str})
+# a specification for a single permitted type
+SingleTypeConstraint = Union[RefTypeConstraint, PrimitiveTypeConstraint]
 
-TypeEntry = Union[RefTypeEntry, PrimitiveTypeEntry]
+# syntax for specifying that a property's values may have one of multiple types
+MultipleTypeConstraint = TypedDict('MultipleTypeConstraint', {'oneOf': list[SingleTypeConstraint]})
 
-MultipleTypeConstraint = TypedDict('MultipleTypeConstraint', {'oneOf': list[TypeEntry]})
 
-
-# a listing of valid types for a property based on constraints,
-# NOT including whether it's an array
-TypeListing = Union[
+# a listing of valid types for values of a property, independent of how many values it may have.
+# this is also the syntax for any type restrictions on a property that may contain only a single value.
+SingletonTypeConstraintExpression = Union[
     MultipleTypeConstraint,
-    TypeEntry,
+    SingleTypeConstraint,
 ]
 
 
-ArrayFieldTypeInformation = TypedDict(
-    'ArrayFieldTypeInformation',
+# syntax for type restrictions on a property that contains an array of values
+ArrayTypeConstraintExpression = TypedDict(
+    'ArrayTypeConstraintExpression',
     {
         'type': Literal['array'],
-        'items': TypeListing,
+        'items': SingletonTypeConstraintExpression,
     }
 )
 
-TypeInformation = Union[TypeListing, ArrayFieldTypeInformation]
+# all possible syntaxes for expressing what data types are permitted for a property
+# in our JSON schema
+TypeConstraintExpression = Union[SingletonTypeConstraintExpression, ArrayTypeConstraintExpression]
+
+
+# an alias for strings to explicitly say "this is the name of an RDF node"
+class RdfNodeName(str):
+    pass
 
 
 class PropertyType(Protocol):
     @property
     def name(self) -> str: ...
-    def type_entry(self) -> TypeEntry: ...
+    def type_constraint_dict(self) -> SingleTypeConstraint: ...

--- a/tools/data-model-exporter/data_model_exporter/typing.py
+++ b/tools/data-model-exporter/data_model_exporter/typing.py
@@ -1,0 +1,39 @@
+from typing import Any, Literal, Protocol, TypedDict, Union
+
+JsonSchema = dict[str, Any]
+
+# a type annotation is either:
+#  * a reference type (e.g. {"$ref": "some:thing"})
+#  * a primitive type (e.g. {"type": "string"})
+
+RefTypeEntry = TypedDict('RefTypeEntry', {'$ref': str})
+PrimitiveTypeEntry = TypedDict('PrimitiveTypeEntry', {'type': str})
+
+TypeEntry = Union[RefTypeEntry, PrimitiveTypeEntry]
+
+MultipleTypeConstraint = TypedDict('MultipleTypeConstraint', {'oneOf': list[TypeEntry]})
+
+
+# a listing of valid types for a property based on constraints,
+# NOT including whether it's an array
+TypeListing = Union[
+    MultipleTypeConstraint,
+    TypeEntry,
+]
+
+
+ArrayFieldTypeInformation = TypedDict(
+    'ArrayFieldTypeInformation',
+    {
+        'type': Literal['array'],
+        'items': TypeListing,
+    }
+)
+
+TypeInformation = Union[TypeListing, ArrayFieldTypeInformation]
+
+
+class PropertyType(Protocol):
+    @property
+    def name(self) -> str: ...
+    def type_entry(self) -> TypeEntry: ...

--- a/tools/data-model-exporter/data_model_exporter/typing.py
+++ b/tools/data-model-exporter/data_model_exporter/typing.py
@@ -1,3 +1,8 @@
+"""
+type annotations and schema definitions used elsewhere in the code base live here.
+
+if this file grows, consider splitting it up by purpose/category rather than allowing it to exceed ~100 lines
+"""
 from typing import Any, Literal, Protocol, TypedDict, Union
 
 JsonSchema = dict[str, Any]

--- a/tools/data-model-exporter/mypy.ini
+++ b/tools/data-model-exporter/mypy.ini
@@ -32,3 +32,6 @@ disallow_untyped_defs = False
 
 [mypy-rdflib.*]
 ignore_missing_imports = True
+
+[mypy-cached_property]
+ignore_missing_imports = True

--- a/tools/data-model-exporter/pyproject.toml
+++ b/tools/data-model-exporter/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Quazi Hoque <qhoque@broadinstitute.org>"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
+cached-property = "^1.5.2"
 rdflib = "^5.0.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
[Ticket](https://broadinstitute.atlassian.net/browse/DSPDC-1666)

# This PR
* Refactors the data model exporter to work more like an ETL pipeline
   * `TtlSchemaGenerator` traverses an RDF graph represented in a Turtle file and transforms it into a `Schema` with many `Property`s
   * The `Schema` and `Property` class contain the logic to convert their representations to JSON schema (according to our schema doc)
   * `dmExporter.py` remains as a wrapper around `TtlSchemaGenerator` which determines the work to be done and serializes the resulting Python objects into JSON files when transformation completes.
 * Adds parsing and transformation logic for all restriction properties under a given class as well as all top-level property definitions within the given class's domain.
 * Adds unit testing for the new classes resulting from this refactor, including some end-to-end tests in the `TtlSchemaGenerator` tests.
 * Adds support for dynamically determining the primary namespace of a TTL file when parsing it (previously we had hardcoded the primary namespace to the Terra DCAT namespace)

# Potential future work
* `TtlSchemaGenerator` is basically just a massive branching if statement, which could get harder to reason about as we expand it. We should keep an eye on this and refactor when necessary.
* The type constraints on property type annotations (i.e. the types properties are allowed to contain in the schema) are _very_  strict and narrowly defined, while the type constraints for the schema overall are very laissez-faire. Given how rigid we want this schema to be, we might benefit from carefully restricting its syntax with Python type hints.