### PR TITLE
Column names

### DIFF
--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -1,4 +1,5 @@
 # baseURI: https://datamodel.terra.bio/TerraCore
+# imports: http://datashapes.org/dash
 # imports: http://www.w3.org/2002/07/owl
 # imports: https://datamodel.terra.bio/EFO_subset
 # imports: https://datamodel.terra.bio/NCBITaxon_Organisms_subset
@@ -59,6 +60,7 @@ prov:used
   dct:date "20 Jul 2020" ;
   dct:license <https://github.com/DataBiosphere/terra-interoperability-model/blob/master/LICENSE> ;
   rdfs:comment "Please cite The Broad Institute of Harvard and MIT, Data Sciences Platform." ;
+  owl:imports <http://datashapes.org/dash> ;
   owl:imports <http://www.w3.org/2002/07/owl> ;
   owl:imports <https://datamodel.terra.bio/EFO_subset> ;
   owl:imports <https://datamodel.terra.bio/NCBITaxon_Organisms_subset> ;
@@ -1282,6 +1284,12 @@ TerraCore:hasClonality
           "polyclonal"
         ) ;
     ] ;
+.
+TerraCore:hasColumnLabel
+  a owl:AnnotationProperty ;
+  rdfs:label "has column label" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has column label" ;
 .
 TerraCore:hasCountry
   a owl:ObjectProperty ;

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -32,6 +32,15 @@
 obo:BFO_0000001
   owl:equivalentClass prov:Entity ;
 .
+dct:contributor
+  TerraCore:hasColumnLabel "contributor" ;
+.
+dct:title
+  TerraCore:hasColumnLabel "title" ;
+.
+dcat:contactPoint
+  TerraCore:hasColumnLabel "contact_point" ;
+.
 prov:Agent
   owl:equivalentClass dct:Agent ;
   owl:equivalentClass <http://xmlns.com/foaf/0.1/Agent> ;
@@ -42,6 +51,9 @@ prov:Entity
 prov:Person
   owl:equivalentClass <http://xmlns.com/foaf/0.1/Person> ;
 .
+prov:generated
+  TerraCore:hasColumnLabel "generated" ;
+.
 prov:hadDerivation
   a owl:ObjectProperty ;
   rdfs:label "hadDerivation" ;
@@ -50,6 +62,10 @@ prov:hadDerivation
 .
 prov:used
   owl:inverseOf prov:wasUsedBy ;
+  TerraCore:hasColumnLabel "used" ;
+.
+prov:wasGeneratedBy
+  TerraCore:hasColumnLabel "generated_by" ;
 .
 <http://xmlns.com/foaf/0.1/Agent>
   owl:equivalentClass prov:Agent ;
@@ -167,6 +183,7 @@ TerraCore:Alignment
       a owl:Restriction ;
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:usesReferenceAssembly ;
+      TerraCore:hasColumnLabel "reference_assembly" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -960,6 +977,7 @@ TerraCore:Sequencing
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:usesSample ;
+      TerraCore:hasColumnLabel "sample" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1055,6 +1073,7 @@ TerraCore:VariantCalling
       a owl:Restriction ;
       owl:onProperty prov:generated ;
       owl:someValuesFrom TerraCore:VariantCallSet ;
+      TerraCore:hasColumnLabel "generated" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1270,6 +1289,7 @@ TerraCore:hasChecksum
   rdfs:label "hasChecksum" ;
   rdfs:range xsd:string ;
   skos:prefLabel "hasChecksum" ;
+  TerraCore:hasColumnLabel "checksum" ;
 .
 TerraCore:hasChild
   a owl:ObjectProperty ;
@@ -1317,6 +1337,7 @@ TerraCore:hasCrossReference
   rdfs:subPropertyOf skos:closeMatch ;
   skos:definition "Reference to the entity in another electronic system.  The data stored about the entity may vary from system to system, but this relationship asserts that the reference represents the same entity." ;
   skos:prefLabel "hasCrossReference" ;
+  TerraCore:hasColumnLabel "xref" ;
 .
 TerraCore:hasCurrentAddress
   a owl:ObjectProperty ;
@@ -1461,6 +1482,7 @@ TerraCore:hasFileFormat
   rdfs:range xsd:string ;
   rdfs:subPropertyOf dct:format ;
   skos:definition "An indication of the format of an electronic file; include the full file extension including compression extensions." ;
+  TerraCore:hasColumnLabel "file_format" ;
 .
 TerraCore:hasFileSize
   a owl:DatatypeProperty ;
@@ -1893,6 +1915,7 @@ TerraCore:isFundedBy
   a owl:ObjectProperty ;
   rdfs:label "isFundedBy" ;
   skos:definition "A relationship defining the funding source.  The range is expected to include grants, organizations, or a string indicating the funding source." ;
+  TerraCore:hasColumnLabel "funded_by" ;
 .
 TerraCore:isGeneratedByPipeline
   a owl:ObjectProperty ;
@@ -1944,6 +1967,7 @@ TerraCore:usesReferenceAssembly
   rdfs:range TerraCore:ReferenceAssembly ;
   rdfs:subPropertyOf prov:used ;
   skos:prefLabel "usesReferenceAssembly" ;
+  TerraCore:hasColumnLabel "reference_assembly" ;
 .
 TerraCore:usesSample
   a owl:ObjectProperty ;
@@ -1973,6 +1997,16 @@ TerraDCAT_ap:Dataset
       owl:onProperty TerraDCAT_ap:hasCustodian ;
     ] ;
 .
+TerraDCAT_ap:hasDataUseModifier
+  TerraCore:hasColumnLabel "data_use_ modifier" ;
+.
+TerraDCAT_ap:hasDataUsePermission
+  TerraCore:hasColumnLabel "data_use_permission" ;
+.
+TerraDCAT_ap:hasOriginalPublication
+  TerraCore:hasColumnLabel "original_plublication" ;
+.
 TerraDCAT_ap:hasPrincipalInvestigator
   rdfs:range TerraCore:PrincipalInvestigator ;
+  TerraCore:hasColumnLabel "principle_investigator" ;
 .

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -303,31 +303,37 @@ TerraCore:BioSample
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasPreservationState ;
+      TerraCore:hasColumnLabel "preservation_state" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty prov:wasDerivedFrom ;
+      TerraCore:hasColumnLabel "derived_from" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasCrossReference ;
+      TerraCore:hasColumnLabel "cross_reference" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasDonorAge ;
+      TerraCore:hasColumnLabel "donor_age" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty prov:wasUsedBy ;
+      TerraCore:hasColumnLabel "used_by" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasDonor ;
+      TerraCore:hasColumnLabel "donor" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -338,6 +344,7 @@ TerraCore:BioSample
       a owl:Restriction ;
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasBioSampleType ;
+      TerraCore:hasColumnLabel "biosample_type" ;
     ] ;
   skos:altLabel "Biospecimen" ;
   skos:altLabel "Sample" ;
@@ -425,6 +432,7 @@ TerraCore:Donor
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasAgeAtDeath ;
+      TerraCore:hasColumnLabel "age_at_death" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -445,11 +453,13 @@ TerraCore:Donor
       a owl:Restriction ;
       owl:minCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasBioSample ;
+      TerraCore:hasColumnLabel "biosample" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:onProperty dct:isPartOf ;
       owl:someValuesFrom TerraDCAT_ap:Dataset ;
+      TerraCore:hasColumnLabel "dataset" ;
     ] ;
   skos:definition "An organism from which a sample or test result is available" ;
   skos:prefLabel "Donor" ;
@@ -462,11 +472,13 @@ TerraCore:FamilyMember
       a owl:Restriction ;
       owl:hasValue TerraCore:Homo_sapiens ;
       owl:onProperty TerraCore:hasOrganismType ;
+      TerraCore:hasColumnLabel "organism_type" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasAgeAtDeath ;
+      TerraCore:hasColumnLabel "age_at_death" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -477,6 +489,7 @@ TerraCore:FamilyMember
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasEthnicity ;
+      TerraCore:hasColumnLabel "ethnicity" ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1086,6 +1099,7 @@ TerraCore:hasAge
   rdfs:range TerraCore:Age ;
   skos:definition "A reference to the Age of the Donor at the point in time that data was collected or that the BioSample was obtained." ;
   skos:prefLabel "hasAge" ;
+  TerraCore:hasColumnLabel "age" ;
 .
 TerraCore:hasAgeAtDeath
   a owl:ObjectProperty ;
@@ -1653,6 +1667,7 @@ TerraCore:hasPhenotypicSex
   rdfs:range TerraCore:BiologicalSex ;
   skos:definition "A reference to the BiologicalSex of the Donor organism." ;
   skos:prefLabel "hasPhenotypicSex" ;
+  TerraCore:hasColumnLabel "phenotypic_sex" ;
 .
 TerraCore:hasPostalCode
   a rdf:Property ;
@@ -1746,6 +1761,7 @@ TerraCore:hasSexAssignedAtBirth
   rdfs:range TerraCore:BiologicalSex ;
   skos:definition "A reference to the BiologicalSex assigned to the donor organism at birth by a medical professional." ;
   skos:prefLabel "hasSexAssignedAtBirth" ;
+  TerraCore:hasColumnLabel "sex_assigned_at_birth" ;
 .
 TerraCore:hasSibling
   a owl:ObjectProperty ;


### PR DESCRIPTION
Added hasColumnName annotation property onto many properties, following the Anvil template. Currently nothing has been done with the rdfs:label and skos:prefLabel.

Will need to update these as we go through more tickets.

Have not implemented anything regarding the prefixes, suffixes, and many-to-1 mappings (might be a good task for SHACL)