### PR TITLE
Perturbations

### DIFF
--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -569,6 +569,12 @@ TerraCore:GeneralResearchUse
   rdfs:label "General Research Use" ;
   skos:prefLabel "General Research Use" ;
 .
+TerraCore:GeneticModification
+  a owl:Class ;
+  rdfs:label "Genetic modification" ;
+  rdfs:subClassOf TerraCore:Perturbation ;
+  skos:prefLabel "Genetic modification" ;
+.
 TerraCore:GrCh38
   a TerraCore:ReferenceAssembly ;
   rdfs:label "GRCh38" ;
@@ -741,6 +747,12 @@ TerraCore:OntologyReference
   a owl:Class ;
   rdfs:label "OntologyReference" ;
   rdfs:subClassOf obo:IAO_0000027 ;
+.
+TerraCore:Perturbation
+  a owl:Class ;
+  rdfs:label "Perturbation" ;
+  rdfs:subClassOf TerraCore:Activity ;
+  skos:prefLabel "Perturbation" ;
 .
 TerraCore:Pipeline
   a owl:Class ;
@@ -918,6 +930,12 @@ TerraCore:Sample
     ] ;
   skos:definition "Data about a physical material collected for the purpose of research." ;
   skos:prefLabel "Sample" ;
+.
+TerraCore:SampleTreatment
+  a owl:Class ;
+  rdfs:label "Sample treatment" ;
+  rdfs:subClassOf TerraCore:Perturbation ;
+  skos:prefLabel "Sample treatment" ;
 .
 TerraCore:SequenceFile
   a owl:Class ;
@@ -1459,6 +1477,20 @@ TerraCore:hasDuplicateFragments
   rdfs:range xsd:integer ;
   skos:prefLabel "hasDuplicateFragments" ;
 .
+TerraCore:hasDurationUnit
+  a owl:DatatypeProperty ;
+  rdfs:label "has duration unit" ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "min"
+          "seconds"
+          "fahrenheit"
+        ) ;
+    ] ;
+  rdfs:subPropertyOf TerraCore:hasUnit ;
+  skos:prefLabel "has duration unit" ;
+.
 TerraCore:hasEstimatedLibrarySize
   a owl:DatatypeProperty ;
   rdfs:comment "For alignment file types." ;
@@ -1531,6 +1563,20 @@ TerraCore:hasGeneExpressionProgram
   rdfs:range xsd:string ;
   skos:definition "A property that characterizes the gene expression patterns at work in the cell." ;
   skos:prefLabel "hasGeneExpressionProgram" ;
+.
+TerraCore:hasGeneticModificationMethod
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:GeneticModification ;
+  rdfs:label "has genetic modification method" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has genetic modification method" ;
+.
+TerraCore:hasGeneticModificationType
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:GeneticModification ;
+  rdfs:label "has genetic modification type" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has genetic modification type" ;
 .
 TerraCore:hasGenotypicSex
   a owl:ObjectProperty ;
@@ -1706,6 +1752,7 @@ TerraCore:hasPerturbation
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:BioSample ;
   rdfs:label "has perturbation" ;
+  rdfs:range TerraCore:Perturbation ;
   skos:prefLabel "has perturbation" ;
 .
 TerraCore:hasPhenotypicSex
@@ -1784,6 +1831,22 @@ TerraCore:hasReadLength
   rdfs:range xsd:integer ;
   skos:prefLabel "hasReadLength" ;
 .
+TerraCore:hasSampleTreatment
+  a owl:ObjectProperty ;
+  rdfs:domain TerraCore:BioSample ;
+  rdfs:label "has sample treatment" ;
+  rdfs:range TerraCore:SampleTreatment ;
+  rdfs:subPropertyOf TerraCore:hasPerturbation ;
+  skos:prefLabel "has sample treatment" ;
+.
+TerraCore:hasSampleTreatmentType
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:SampleTreatment ;
+  rdfs:label "has sample treatment type" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has sample treatment type" ;
+  TerraCore:hasColumnLabel "sample_treatment_type" ;
+.
 TerraCore:hasSampleType
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:Sample ;
@@ -1858,6 +1921,21 @@ TerraCore:hasTarget
   rdfs:label "hasTarget" ;
   rdfs:range xsd:anyURI ;
   skos:prefLabel "hasTarget" ;
+.
+TerraCore:hasTemperatureUnit
+  a owl:DatatypeProperty ;
+  rdfs:label "has temperature unit" ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "celsius"
+          "kelvin"
+          "fahrenheit"
+        ) ;
+    ] ;
+  rdfs:subPropertyOf TerraCore:hasUnit ;
+  skos:prefLabel "has temperature unit" ;
+  TerraCore:hasColumnLabel "temperature_unit" ;
 .
 TerraCore:hasTermName
   a owl:DatatypeProperty ;

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -1,4 +1,5 @@
 # baseURI: https://datamodel.terra.bio/TerraCore
+# imports: http://datashapes.org/dash
 # imports: http://www.w3.org/2002/07/owl
 # imports: https://datamodel.terra.bio/EFO_subset
 # imports: https://datamodel.terra.bio/NCBITaxon_Organisms_subset
@@ -90,6 +91,7 @@ prov:wasGeneratedBy
   dct:date "20 Jul 2020" ;
   dct:license <https://github.com/DataBiosphere/terra-interoperability-model/blob/master/LICENSE> ;
   rdfs:comment "Please cite The Broad Institute of Harvard and MIT, Data Sciences Platform." ;
+  owl:imports <http://datashapes.org/dash> ;
   owl:imports <http://www.w3.org/2002/07/owl> ;
   owl:imports <https://datamodel.terra.bio/EFO_subset> ;
   owl:imports <https://datamodel.terra.bio/NCBITaxon_Organisms_subset> ;
@@ -572,7 +574,7 @@ TerraCore:GeneralResearchUse
 TerraCore:GeneticModification
   a owl:Class ;
   rdfs:label "Genetic modification" ;
-  rdfs:subClassOf TerraCore:Perturbation ;
+  rdfs:subClassOf TerraCore:Activity ;
   skos:prefLabel "Genetic modification" ;
 .
 TerraCore:GrCh38
@@ -747,12 +749,6 @@ TerraCore:OntologyReference
   a owl:Class ;
   rdfs:label "OntologyReference" ;
   rdfs:subClassOf obo:IAO_0000027 ;
-.
-TerraCore:Perturbation
-  a owl:Class ;
-  rdfs:label "Perturbation" ;
-  rdfs:subClassOf TerraCore:Activity ;
-  skos:prefLabel "Perturbation" ;
 .
 TerraCore:Pipeline
   a owl:Class ;
@@ -934,7 +930,7 @@ TerraCore:Sample
 TerraCore:SampleTreatment
   a owl:Class ;
   rdfs:label "Sample treatment" ;
-  rdfs:subClassOf TerraCore:Perturbation ;
+  rdfs:subClassOf TerraCore:Activity ;
   skos:prefLabel "Sample treatment" ;
 .
 TerraCore:SequenceFile
@@ -1477,6 +1473,13 @@ TerraCore:hasDuplicateFragments
   rdfs:range xsd:integer ;
   skos:prefLabel "hasDuplicateFragments" ;
 .
+TerraCore:hasDuration
+  a owl:DatatypeProperty ;
+  rdfs:label "has duration" ;
+  rdfs:range xsd:decimal ;
+  skos:prefLabel "has duration" ;
+  TerraCore:hasColumnLabel "duration" ;
+.
 TerraCore:hasDurationUnit
   a owl:DatatypeProperty ;
   rdfs:label "has duration unit" ;
@@ -1485,7 +1488,7 @@ TerraCore:hasDurationUnit
       owl:oneOf (
           "min"
           "seconds"
-          "fahrenheit"
+          "hours"
         ) ;
     ] ;
   rdfs:subPropertyOf TerraCore:hasUnit ;
@@ -1564,19 +1567,54 @@ TerraCore:hasGeneExpressionProgram
   skos:definition "A property that characterizes the gene expression patterns at work in the cell." ;
   skos:prefLabel "hasGeneExpressionProgram" ;
 .
+TerraCore:hasGeneticModification
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:BioSample ;
+  rdfs:label "has genetic modification" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has genetic modification" ;
+  prov:definition "Genetic modification of a BioSample." ;
+  TerraCore:hasColumnLabel "genetic_mod" ;
+.
 TerraCore:hasGeneticModificationMethod
   a owl:DatatypeProperty ;
-  rdfs:domain TerraCore:GeneticModification ;
   rdfs:label "has genetic modification method" ;
-  rdfs:range xsd:string ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "CRISPR"
+          "mutagen treatment"
+          "site-specific recombination"
+          "TALEN"
+          "homologous recombination"
+        ) ;
+    ] ;
   skos:prefLabel "has genetic modification method" ;
+  prov:definition "The method of a GeneticModification, see ValueSets." ;
+  TerraCore:hasColumnLabel "genetic_mod_method" ;
 .
 TerraCore:hasGeneticModificationType
   a owl:DatatypeProperty ;
-  rdfs:domain TerraCore:GeneticModification ;
   rdfs:label "has genetic modification type" ;
-  rdfs:range xsd:string ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "deletion"
+          "interference"
+          "insertion"
+          "mutagenesis"
+          "replacement"
+          "episome"
+          "activation"
+          "knockout"
+          "disruption"
+          "inhibition"
+          "binding"
+          "transgene insertion"
+        ) ;
+    ] ;
   skos:prefLabel "has genetic modification type" ;
+  TerraCore:hasColumnLabel "genetic_mod_method" ;
 .
 TerraCore:hasGenotypicSex
   a owl:ObjectProperty ;
@@ -1748,13 +1786,6 @@ TerraCore:hasPercentDuplicateFragments
   rdfs:range xsd:decimal ;
   skos:prefLabel "hasPercentDuplicateFragments" ;
 .
-TerraCore:hasPerturbation
-  a owl:ObjectProperty ;
-  rdfs:domain TerraCore:BioSample ;
-  rdfs:label "has perturbation" ;
-  rdfs:range TerraCore:Perturbation ;
-  skos:prefLabel "has perturbation" ;
-.
 TerraCore:hasPhenotypicSex
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:Donor ;
@@ -1835,16 +1866,14 @@ TerraCore:hasSampleTreatment
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:BioSample ;
   rdfs:label "has sample treatment" ;
-  rdfs:range TerraCore:SampleTreatment ;
-  rdfs:subPropertyOf TerraCore:hasPerturbation ;
   skos:prefLabel "has sample treatment" ;
 .
 TerraCore:hasSampleTreatmentType
   a owl:DatatypeProperty ;
-  rdfs:domain TerraCore:SampleTreatment ;
   rdfs:label "has sample treatment type" ;
   rdfs:range xsd:string ;
   skos:prefLabel "has sample treatment type" ;
+  prov:definition "The type of a BioSample treatment type, see valuesets for examples." ;
   TerraCore:hasColumnLabel "sample_treatment_type" ;
 .
 TerraCore:hasSampleType
@@ -1936,6 +1965,13 @@ TerraCore:hasTemperatureUnit
   rdfs:subPropertyOf TerraCore:hasUnit ;
   skos:prefLabel "has temperature unit" ;
   TerraCore:hasColumnLabel "temperature_unit" ;
+.
+TerraCore:hasTempterature
+  a rdf:Property ;
+  rdfs:label "has tempterature" ;
+  rdfs:range xsd:decimal ;
+  skos:prefLabel "has tempterature" ;
+  TerraCore:hasColumnLabel "temperature" ;
 .
 TerraCore:hasTermName
   a owl:DatatypeProperty ;
@@ -2055,6 +2091,7 @@ TerraCore:usesAntibody
   rdfs:range TerraCore:Antibody ;
   rdfs:subPropertyOf prov:used ;
   skos:prefLabel "usesAntibody" ;
+  prov:definition "May be a reference to an antibody used for a SampleTreatment or other Activity." ;
 .
 TerraCore:usesLibrary
   a owl:ObjectProperty ;

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -1576,6 +1576,7 @@ TerraCore:hasGeneticModification
 .
 TerraCore:hasGeneticModificationMethod
   a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:BioSample ;
   rdfs:label "has genetic modification method" ;
   rdfs:range [
       a rdfs:Datatype ;
@@ -1593,6 +1594,7 @@ TerraCore:hasGeneticModificationMethod
 .
 TerraCore:hasGeneticModificationType
   a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:BioSample ;
   rdfs:label "has genetic modification type" ;
   rdfs:range [
       a rdfs:Datatype ;
@@ -1868,11 +1870,20 @@ TerraCore:hasSampleTreatment
 .
 TerraCore:hasSampleTreatmentType
   a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:BioSample ;
   rdfs:label "has sample treatment type" ;
   rdfs:range [
       a rdfs:Datatype ;
       owl:oneOf (
-          "1"
+          "antibody"
+          "chemical"
+          "exposure"
+          "infection"
+          "injection"
+          "irradiation"
+          "protein"
+          "transplantation"
+          "RNAi"
         ) ;
     ] ;
   skos:prefLabel "has sample treatment type" ;

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -574,7 +574,6 @@ TerraCore:GeneralResearchUse
 TerraCore:GeneticModification
   a owl:Class ;
   rdfs:label "Genetic modification" ;
-  rdfs:subClassOf TerraCore:Activity ;
   skos:prefLabel "Genetic modification" ;
 .
 TerraCore:GrCh38
@@ -930,7 +929,6 @@ TerraCore:Sample
 TerraCore:SampleTreatment
   a owl:Class ;
   rdfs:label "Sample treatment" ;
-  rdfs:subClassOf TerraCore:Activity ;
   skos:prefLabel "Sample treatment" ;
 .
 TerraCore:SequenceFile
@@ -1871,7 +1869,12 @@ TerraCore:hasSampleTreatment
 TerraCore:hasSampleTreatmentType
   a owl:DatatypeProperty ;
   rdfs:label "has sample treatment type" ;
-  rdfs:range xsd:string ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "1"
+        ) ;
+    ] ;
   skos:prefLabel "has sample treatment type" ;
   prov:definition "The type of a BioSample treatment type, see valuesets for examples." ;
   TerraCore:hasColumnLabel "sample_treatment_type" ;

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -32,6 +32,9 @@
 obo:BFO_0000001
   owl:equivalentClass prov:Entity ;
 .
+obo:DUO_0000017
+  rdfs:subClassOf dcat:Resource ;
+.
 dct:contributor
   TerraCore:hasColumnLabel "contributor" ;
 .
@@ -571,11 +574,6 @@ TerraCore:GeneralResearchUse
   rdfs:label "General Research Use" ;
   skos:prefLabel "General Research Use" ;
 .
-TerraCore:GeneticModification
-  a owl:Class ;
-  rdfs:label "Genetic modification" ;
-  skos:prefLabel "Genetic modification" ;
-.
 TerraCore:GrCh38
   a TerraCore:ReferenceAssembly ;
   rdfs:label "GRCh38" ;
@@ -925,11 +923,6 @@ TerraCore:Sample
     ] ;
   skos:definition "Data about a physical material collected for the purpose of research." ;
   skos:prefLabel "Sample" ;
-.
-TerraCore:SampleTreatment
-  a owl:Class ;
-  rdfs:label "Sample treatment" ;
-  skos:prefLabel "Sample treatment" ;
 .
 TerraCore:SequenceFile
   a owl:Class ;

--- a/tools/data-model-exporter/pyproject.toml
+++ b/tools/data-model-exporter/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Quazi Hoque <qhoque@broadinstitute.org>"]
 python = "^3.9"
 cached-property = "^1.5.2"
 rdflib = "^5.0.0"
+Owlready2 = "^0.37"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.5"


### PR DESCRIPTION
I removed SampleTreatment and GeneticModification as classes. Now pertubations just consist of a series of DataType properties which have domain of BioSample: hasSampleTreatment, hasGeneticModification, hasSampleTreatmentType, hasSampleTreatmentMethod, hasGeneticModifcationType, hasGeneticModificationMethod

I felt that removing SampleTreatment and GeneticModification from being subclasses of activities didn't really give them a reason to exist as separate tables. They are modifications of BioSample, so I thought that is a simpler place to store them.

Happy to discuss modelling perturbations as their own classes.

I did not model hasPurpose, that seemed a bit generic to me and can be tackled later when we have more actual examples of perturbation data.