### PR TITLE
Update Donor properties. DM-384

### DIFF
--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -352,7 +352,7 @@ TerraCore:BioSample
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasDonorAge ;
+      owl:onProperty TerraCore:hasDonorAgeAtCollection ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -507,6 +507,11 @@ TerraCore:FamilyMember
       a owl:Restriction ;
       owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasPhenotypicSex ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasGeneticAncestry ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1454,13 +1459,13 @@ TerraCore:hasDonor
   skos:definition "This property references the Donor organism from which the BioSample was acquired." ;
   skos:prefLabel "hasDonor" ;
 .
-TerraCore:hasDonorAge
+TerraCore:hasDonorAgeAtCollection
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:BioSample ;
-  rdfs:label "hasDonorAge" ;
+  rdfs:label "hasDonorAgeAtCollection" ;
   rdfs:range TerraCore:Age ;
   skos:definition "A reference to the Age of the Donor at the point in time that the BioSample was obtained or other representative entity (test, diagnosis, treatment...) was created." ;
-  skos:prefLabel "hasDonorAge" ;
+  skos:prefLabel "hasDonorAgeAtCollection" ;
   TerraCore:hasColumnLabel "donor_age_at_collection" ;
 .
 TerraCore:hasDuplicateFragments

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -43,6 +43,12 @@ dct:license
 dct:title
   TerraCore:hasColumnLabel "title" ;
 .
+prov:endedAtTime
+  TerraCore:hasColumnLabel "end_time" ;
+.
+prov:generated
+  TerraCore:hasColumnLabel "generated" ;
+.
 dcat:contactPoint
   TerraCore:hasColumnLabel "contact_point" ;
 .
@@ -468,7 +474,7 @@ TerraCore:Donor
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasMedicalHistory ;
+      owl:onProperty TerraCore:hasCrossReference ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -505,7 +511,7 @@ TerraCore:FamilyMember
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasEthnicity ;
+      owl:onProperty TerraCore:hasGeneticAncestry ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -517,6 +523,7 @@ TerraCore:FamilyMember
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasRace ;
     ] ;
+  skos:definition "Family member has biological relationship to a Donor.  Limited health information.  A family member for whom samples, imaging studies, lab tests or other healthcare information is available may be considered a Donor." ;
 .
 TerraCore:Female
   a TerraCore:FemaleSex ;
@@ -1041,12 +1048,12 @@ TerraCore:VariantCall
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:onProperty prov:used ;
-      owl:someValuesFrom TerraCore:VariantCallSet ;
+      owl:someValuesFrom TerraCore:VariantCallSetFile ;
     ] ;
   skos:prefLabel "VariantCall" ;
   prov:definition "A variation in genetic sequence for a particular Sample and VariantCallingActivity." ;
 .
-TerraCore:VariantCallSet
+TerraCore:VariantCallSetFile
   a owl:Class ;
   rdfs:label "VariantCallSet" ;
   rdfs:subClassOf TerraCore:File ;
@@ -1070,7 +1077,7 @@ TerraCore:VariantCalling
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:onProperty prov:generated ;
-      owl:someValuesFrom TerraCore:VariantCallSet ;
+      owl:someValuesFrom TerraCore:VariantCallSetFile ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -1361,18 +1368,6 @@ TerraCore:hasDataModality
   rdfs:range TerraCoreValueSets:DataModality ;
   TerraCore:hasColumnLabel "data_modality" ;
 .
-TerraCore:hasDataUseLimitation
-  rdfs:domain TerraCore:Donor ;
-  rdfs:domain TerraCore:File ;
-  rdfs:domain TerraCore:Library ;
-  rdfs:domain TerraCore:Sample ;
-.
-TerraCore:hasDataUseRequirement
-  rdfs:domain TerraCore:Donor ;
-  rdfs:domain TerraCore:File ;
-  rdfs:domain TerraCore:Library ;
-  rdfs:domain TerraCore:Sample ;
-.
 TerraCore:hasDateCollected
   a rdf:Property ;
   a owl:DatatypeProperty ;
@@ -1390,8 +1385,8 @@ TerraCore:hasDateOfBirth
   rdfs:domain TerraCore:Donor ;
   rdfs:domain TerraCore:FamilyMember ;
   rdfs:label "has date of birth" ;
-  rdfs:range xsd:date ;
-  rdfs:subPropertyOf dct:date ;
+  rdfs:range xsd:dateTime ;
+  skos:definition "A reference to the data of birth of the Donor or Family Member." ;
   TerraCore:hasColumnLabel "birth_date" ;
 .
 TerraCore:hasDateOfDeath
@@ -1414,6 +1409,7 @@ TerraCore:hasDevelopmentalStage
 .
 TerraCore:hasDiagnosis
   a owl:ObjectProperty ;
+  rdfs:domain TerraCore:BioSample ;
   rdfs:domain TerraCore:FamilyMember ;
   rdfs:domain TerraCore:HumanDonor ;
   rdfs:label "hasDiagnosis" ;
@@ -1432,6 +1428,23 @@ TerraCore:hasDisease
   skos:definition "A property that identifies a disease or condition has been reported in this entity." ;
   skos:prefLabel "hasDisease" ;
 .
+TerraCore:hasDiseaseStageType
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:Diagnosis ;
+  rdfs:label "disease stage type" ;
+  rdfs:range dct:URI ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has disease stage type" ;
+  TerraCore:hasColumnLabel "disease_stage_type" ;
+.
+TerraCore:hasDiseaseStageValue
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:Diagnosis ;
+  rdfs:label "disease stage" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has disease stage value" ;
+  TerraCore:hasColumnLabel "disease_stage_value" ;
+.
 TerraCore:hasDonor
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:BioSample ;
@@ -1446,9 +1459,9 @@ TerraCore:hasDonorAge
   rdfs:domain TerraCore:BioSample ;
   rdfs:label "hasDonorAge" ;
   rdfs:range TerraCore:Age ;
-  skos:definition "A reference to the Age of the Donor at the point in time that the BioSample was obtained." ;
+  skos:definition "A reference to the Age of the Donor at the point in time that the BioSample was obtained or other representative entity (test, diagnosis, treatment...) was created." ;
   skos:prefLabel "hasDonorAge" ;
-  TerraCore:hasColumnLabel "donor_age" ;
+  TerraCore:hasColumnLabel "donor_age_at_collection" ;
 .
 TerraCore:hasDuplicateFragments
   a owl:DatatypeProperty ;
@@ -1467,17 +1480,6 @@ TerraCore:hasEstimatedLibrarySize
   rdfs:label "hasEstimatedLibrarySize" ;
   rdfs:range xsd:integer ;
   skos:prefLabel "hasEstimatedLibrarySize" ;
-.
-TerraCore:hasEthnicity
-  a owl:DatatypeProperty ;
-  rdfs:comment "Recommend using HANCESTRO ancestry category subclasses as options here.  In the meantime, capturing a text string.  " ;
-  rdfs:domain TerraCore:FamilyMember ;
-  rdfs:domain TerraCore:HumanDonor ;
-  rdfs:label "has ethnicity" ;
-  rdfs:range xsd:string ;
-  skos:definition "A property that relects a HumanDonor's reported major contributing ethnic origins. " ;
-  skos:prefLabel "has ethnicity" ;
-  TerraCore:hasColumnLabel "ethnicity" ;
 .
 TerraCore:hasFamilyID
   a owl:ObjectProperty ;
@@ -1532,11 +1534,22 @@ TerraCore:hasGeneExpressionProgram
   skos:definition "A property that characterizes the gene expression patterns at work in the cell." ;
   skos:prefLabel "hasGeneExpressionProgram" ;
 .
+TerraCore:hasGeneticAncestry
+  a owl:DatatypeProperty ;
+  rdfs:comment "Recommend using HANCESTRO ancestry category subclasses as options here. " ;
+  rdfs:domain TerraCore:FamilyMember ;
+  rdfs:domain TerraCore:HumanDonor ;
+  rdfs:label "has genetic ancestry" ;
+  rdfs:range xsd:anyURI ;
+  skos:definition "A property that relects a HumanDonor's reported major contributing ancestral origins  based on genetic/genomic data." ;
+  skos:prefLabel "has genetic ancestry" ;
+  TerraCore:hasColumnLabel "genetic_ancestry" ;
+.
 TerraCore:hasGenotypicSex
-  a owl:ObjectProperty ;
+  a xsd:string ;
+  rdfs:comment "Add equivalence to http://purl.obolibrary.org/obo/PATO_0020000" ;
   rdfs:domain TerraCore:Donor ;
   rdfs:label "hasGenotypicSex" ;
-  rdfs:range TerraCore:BiologicalSex ;
   skos:definition "A biological sex quality inhering in an individual based upon genotypic composition of sex chromosomes. [PATO]" ;
   skos:prefLabel "hasGenotypicSex" ;
   TerraCore:hasColumnLabel "genotypic_sex" ;
@@ -1617,11 +1630,19 @@ TerraCore:hasMannerOfDeath
   rdfs:range xsd:string ;
   skos:prefLabel "has manner of death" ;
 .
-TerraCore:hasMedicalHistory
-  a owl:ObjectProperty ;
-  rdfs:domain TerraCore:Donor ;
-  rdfs:label "hasMedicalHistory" ;
-  rdfs:range TerraCore:MedicalHistory ;
+TerraCore:hasMissingValueReason
+  a owl:AnnotationProperty ;
+  rdfs:comment "The reason choices are taken from the International Nucleotide Sequencing Data Collaborative (INSDC); see https://www.insdc.org/missing-value-reporting#." ;
+  rdfs:label "has missing value reason" ;
+  rdfs:range [
+      a rdfs:Datatype ;
+      owl:oneOf (
+          "not applicable"
+          "not collected"
+          "restricted"
+        ) ;
+    ] ;
+  TerraCore:hasColumnLabel "missing_value_reason" ;
 .
 TerraCore:hasMolecularSampleType
   a owl:ObjectProperty ;
@@ -1702,18 +1723,13 @@ TerraCore:hasPercentDuplicateFragments
   rdfs:range xsd:decimal ;
   skos:prefLabel "hasPercentDuplicateFragments" ;
 .
-TerraCore:hasPerturbation
-  a owl:ObjectProperty ;
-  rdfs:domain TerraCore:BioSample ;
-  rdfs:label "has perturbation" ;
-  skos:prefLabel "has perturbation" ;
-.
 TerraCore:hasPhenotypicSex
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:Donor ;
   rdfs:label "hasPhenotypicSex" ;
   rdfs:range TerraCore:BiologicalSex ;
-  skos:definition "A reference to the BiologicalSex of the Donor organism." ;
+  owl:equivalentProperty obo:PATO_0001894 ;
+  skos:definition "A reference to the BiologicalSex of the Donor organism. \"An organismal quality inhering in a bearer by virtue of the bearer's physical expression of sexual characteristics. [PATO]\"" ;
   skos:prefLabel "hasPhenotypicSex" ;
   TerraCore:hasColumnLabel "phenotypic_sex" ;
 .
@@ -1784,6 +1800,18 @@ TerraCore:hasReadLength
   rdfs:range xsd:integer ;
   skos:prefLabel "hasReadLength" ;
 .
+TerraCore:hasReportedEthnicity
+  a owl:DatatypeProperty ;
+  rdfs:comment "Recommend using HANCESTRO ancestry category subclasses but a text string is also acceptable." ;
+  rdfs:domain TerraCore:FamilyMember ;
+  rdfs:domain TerraCore:HumanDonor ;
+  rdfs:label "has reported ethnicity" ;
+  rdfs:range xsd:anyURI ;
+  rdfs:range xsd:string ;
+  skos:definition "A property that relects a HumanDonor's reported ethnic origins. " ;
+  skos:prefLabel "has reported ethnicity" ;
+  TerraCore:hasColumnLabel "reported_ethnicity" ;
+.
 TerraCore:hasSampleType
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:Sample ;
@@ -1844,10 +1872,11 @@ TerraCore:hasStopPosition
 .
 TerraCore:hasStrain
   a owl:DatatypeProperty ;
-  rdfs:domain TerraCore:MouseDonor ;
+  rdfs:domain rdfs:Resource ;
+  rdfs:domain TerraCore:Donor ;
   rdfs:label "hasStrain" ;
   rdfs:range xsd:string ;
-  skos:definition "Text string to represent the strain." ;
+  skos:definition "Text string to represent the strain of the donor organism." ;
   skos:prefLabel "hasStrain" ;
 .
 TerraCore:hasTarget
@@ -1892,7 +1921,7 @@ TerraCore:hasUpperBound
 .
 TerraCore:hasVariantCall
   a owl:ObjectProperty ;
-  rdfs:domain TerraCore:VariantCallSet ;
+  rdfs:domain TerraCore:VariantCallSetFile ;
   rdfs:label "hasVariantCall" ;
   rdfs:range TerraCore:VariantCall ;
   skos:prefLabel "hasVariantCall" ;


### PR DESCRIPTION
Change hasEthnicity to hasReportedEthnicity and hasGeneticAncestry.
Capture reason for missing data in an annotation
Remove Age and Medical History
Add definition for FamilyMember
Added hasDiseaseStage and updated definitions; dateOfBirth needs to be date/time; a day is not granular enough.
To capture the strain of model organisms other than Mouse, added this is an optional property for all Donors (clearly nonsensical for Humans though).