### PR TITLE
[DDO-2069] Fix the image URL from the 1.x-to-2.x change

### DIFF
--- a/webpages/www/TerraCoreDataModel.html
+++ b/webpages/www/TerraCoreDataModel.html
@@ -100,7 +100,7 @@ ul.a {
 <p>The following diagram illustrates selected key concepts and relationships to provide an overview of the model.
 </p>
 <br><br>
-<img src="https://github.com/DataBiosphere/terra-interoperability-model/blob/master/documents/Terra%20Interoperability%20Model%20v2%20High%20Level.png"
+<img src="https://raw.githubusercontent.com/DataBiosphere/terra-interoperability-model/master/documents/Terra%20Interoperability%20Model%20v2%20High%20Level.png"
 	alt="Figure - Terra Interoperability Model Overview"
 	class="center"
 >


### PR DESCRIPTION
It looks like https://github.com/DataBiosphere/terra-interoperability-model/commit/a2100551233416c77c2d772ef34f14292ee768fb#diff-1315eb195197fe65182c1256ef7ff02c86350aac07012014cf4f70d6d44868f9R103 typo'ed the image URL--linking the GitHub UI page URL for the image, not the raw URL for it. Merging this will generate an image we can slot into our new Terraform to seamlessly fix the issue.