### PR TITLE
Add Measurement, Dose, Treatment

### DIFF
--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -383,17 +383,6 @@ TerraCore:BioSample
   rdfs:subClassOf TerraCore:Sample ;
   rdfs:subClassOf [
       a owl:Restriction ;
-      owl:allValuesFrom [
-          a rdfs:Datatype ;
-          owl:oneOf (
-              "primary"
-              "metastatic"
-            ) ;
-        ] ;
-      owl:onProperty TerraCore:hasPrimaryOrMetastaticIndicator ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
       owl:cardinality "1"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:id ;
     ] ;
@@ -616,6 +605,28 @@ TerraCore:Donor
     ] ;
   skos:definition "An organism from which a sample or test result is available" ;
   skos:prefLabel "Donor" ;
+.
+TerraCore:Dose
+  a owl:Class ;
+  rdfs:label "Dose" ;
+  rdfs:subClassOf obo:BFO_0000040 ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:decimal ;
+      owl:onProperty prov:value ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty prov:value ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasUnit ;
+    ] ;
+  skos:definition "A measured amount of a substance." ;
+  skos:prefLabel "Dose" ;
 .
 TerraCore:ExperimentActivity
   a owl:Class ;
@@ -854,12 +865,22 @@ TerraCore:HumanDonor
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasMeasurement ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasParent ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
       owl:minCardinality "0"^^xsd:nonNegativeInteger ;
       owl:onProperty TerraCore:hasSibling ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasTreatment ;
     ] ;
   rdfs:subClassOf [
       a owl:Restriction ;
@@ -946,6 +967,53 @@ TerraCore:MaleSex
   rdfs:subClassOf TerraCore:BiologicalSex ;
   owl:equivalentClass obo:PATO_0000384 ;
   skos:altLabel "M" ;
+.
+TerraCore:Measurement
+  a owl:Class ;
+  rdfs:label "Measurement" ;
+  rdfs:subClassOf obo:IAO_0000030 ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:allValuesFrom xsd:decimal ;
+      owl:onProperty prov:value ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty prov:value ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasMeasurementType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasMeasurementType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:id ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty prov:generated ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:onProperty prov:generated ;
+      owl:someValuesFrom TerraCore:File ;
+    ] ;
+  skos:definition "The record of the size, quantity or outcome of a clinical or laboratory test." ;
+  skos:prefLabel "Measurement" ;
 .
 TerraCore:MolecularSample
   a owl:Class ;
@@ -1331,6 +1399,53 @@ TerraCore:SingleCellIsolationActivity
       owl:onProperty TerraCore:hasDataModality ;
     ] ;
   skos:definition "Activity to separate individual cells or nuclei. " ;
+.
+TerraCore:TreatmentActivity
+  a owl:Class ;
+  rdfs:label "Treatment" ;
+  rdfs:subClassOf TerraCore:Activity ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasTreatmentType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:id ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDonorAgeAtCollection ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDose ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDuration ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDurationUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasMedication ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasTreatmentOutcome ;
+    ] ;
+  skos:definition "Activities or processes undertaken with the expectation of therapeutic value." ;
+  skos:prefLabel "Treatment" ;
 .
 TerraCore:UserRestriction
   a obo:DUO_0000026 ;
@@ -1757,6 +1872,7 @@ TerraCore:hasDateCollected
   a rdf:Property ;
   a owl:DatatypeProperty ;
   rdfs:domain TerraCore:BioSample ;
+  rdfs:domain TerraCore:Measurement ;
   rdfs:label "has date collected" ;
   rdfs:range xsd:dateTime ;
   rdfs:subPropertyOf dct:date ;
@@ -1844,11 +1960,30 @@ TerraCore:hasDonor
 TerraCore:hasDonorAgeAtCollection
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:BioSample ;
+  rdfs:domain TerraCore:Measurement ;
   rdfs:label "hasDonorAgeAtCollection" ;
   rdfs:range TerraCore:Age ;
   skos:definition "A reference to the Age of the Donor at the point in time that the BioSample was obtained or other representative entity (test, diagnosis, treatment...) was created." ;
   skos:prefLabel "hasDonorAgeAtCollection" ;
   TerraCore:hasColumnLabel "donor_age_at_collection" ;
+.
+TerraCore:hasDonorAgeAtEvent
+  a owl:ObjectProperty ;
+  rdfs:domain TerraCore:Activity ;
+  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:label "hasDonorAgeAtEvent" ;
+  rdfs:range TerraCore:Age ;
+  skos:definition "A reference to the Age of the Donor at the point in time that the event or administration occured." ;
+  skos:prefLabel "hasDonorAgeAtEvent" ;
+  TerraCore:hasColumnLabel "donor_age_at_event" ;
+.
+TerraCore:hasDose
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:label "has dose" ;
+  skos:definition "A reference to the dosage information relevant to this Treatment or Medication." ;
+  skos:prefLabel "has dose" ;
+  TerraCore:hasColumnLabel "dose" ;
 .
 TerraCore:hasDuplicateFragments
   a owl:DatatypeProperty ;
@@ -2014,7 +2149,7 @@ TerraCore:hasGeneticModificationType
         ) ;
     ] ;
   skos:prefLabel "has genetic modification type" ;
-  TerraCore:hasColumnLabel "genetic_mod_type" ;
+  TerraCore:hasColumnLabel "genetic_mod_method" ;
 .
 TerraCore:hasGenotypicSex
   a owl:DatatypeProperty ;
@@ -2156,6 +2291,36 @@ TerraCore:hasMannerOfDeath
   rdfs:range xsd:string ;
   skos:prefLabel "has manner of death" ;
 .
+TerraCore:hasMeasurement
+  a owl:ObjectProperty ;
+  rdfs:domain TerraCore:Donor ;
+  rdfs:label "has measurement" ;
+  rdfs:range TerraCore:Measurement ;
+  skos:definition "A reference to a Measurement related to this Donor." ;
+  skos:prefLabel "has measurement" ;
+  TerraCore:hasColumnLabel "measurement" ;
+.
+TerraCore:hasMeasurementType
+  a owl:DatatypeProperty ;
+  rdfs:comment "Recommend LOINC or SNOMED vocabularies." ;
+  rdfs:domain TerraCore:Measurement ;
+  rdfs:label "has measurement type" ;
+  rdfs:range dct:URI ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has measurement type" ;
+  TerraCore:hasColumnLabel "measurement_type" ;
+.
+TerraCore:hasMedication
+  a owl:DatatypeProperty ;
+  rdfs:comment "Recommend term or URL from MEDDRA or RxNORM. Note that this model of a medication is subject to change." ;
+  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:label "has medication" ;
+  rdfs:range xsd:anyURI ;
+  rdfs:range xsd:string ;
+  skos:definition "A reference to the medication information relevant to this entity." ;
+  skos:prefLabel "has medication" ;
+  TerraCore:hasColumnLabel "medication" ;
+.
 TerraCore:hasMissingValueReason
   a owl:AnnotationProperty ;
   rdfs:comment "The reason choices are taken from the International Nucleotide Sequencing Data Collaborative (INSDC); see https://www.insdc.org/missing-value-reporting#." ;
@@ -2285,8 +2450,7 @@ TerraCore:hasPlatform
 TerraCore:hasPlatformIdentifier
   a rdf:Property ;
   a owl:DatatypeProperty ;
-  rdfs:domain TerraCore:Donor ;
-  rdfs:domain TerraCore:FamilyMember ;
+  rdfs:domain TerraCore:Activity ;
   rdfs:label "hasPlatformID" ;
   rdfs:range xsd:anyURI ;
   rdfs:range xsd:string ;
@@ -2541,6 +2705,36 @@ TerraCore:hasTermName
   rdfs:label "hasTermName" ;
   rdfs:range xsd:string ;
 .
+TerraCore:hasTreatment
+  a owl:ObjectProperty ;
+  rdfs:domain TerraCore:Diagnosis ;
+  rdfs:domain TerraCore:Donor ;
+  rdfs:domain TerraCore:HumanDonor ;
+  rdfs:label "hasTreatment" ;
+  rdfs:range TerraCore:TreatmentActivity ;
+  skos:definition "A reference to the therapeutic treatment undertaken for this Donor." ;
+  skos:prefLabel "has treatment" ;
+  TerraCore:hasColumnLabel "treatment" ;
+.
+TerraCore:hasTreatmentOutcome
+  a rdf:Property ;
+  a owl:DatatypeProperty ;
+  rdfs:comment "Should the model define a preferred vocabulary? e.g. positive, negative, no effect?  The specific outcome may need to be more specific, reduced tumor size by  .. but the categories listed are useful." ;
+  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:label "has treatment outcome" ;
+  rdfs:range xsd:string ;
+  skos:definition "A reference to the outcome of this Treatment." ;
+  TerraCore:hasColumnLabel "treatment_outcome" ;
+.
+TerraCore:hasTreatmentType
+  a owl:DatatypeProperty ;
+  rdfs:comment "Need to add recommended vocabulary." ;
+  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:label "has treatment type" ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "has treatment type" ;
+  TerraCore:hasColumnLabel "treatment_method" ;
+.
 TerraCore:hasTumorMorphology
   a owl:ObjectProperty ;
   rdfs:label "hasTumorMorphology" ;
@@ -2556,6 +2750,7 @@ TerraCore:hasURI
 TerraCore:hasUnit
   a owl:DatatypeProperty ;
   rdfs:label "hasUnit" ;
+  rdfs:range xsd:string ;
   skos:prefLabel "hasUnit" ;
 .
 TerraCore:hasUpperBound
@@ -2702,6 +2897,16 @@ TerraCore:usesSample
   skos:definition "A reference to the sample used by this activity." ;
   skos:prefLabel "usesSample" ;
   TerraCore:hasColumnLabel "uses_sample" ;
+.
+TerraCore:usesSoftware
+  a owl:DatatypeProperty ;
+  rdfs:domain TerraCore:AnalysisActivity ;
+  rdfs:label "uses software" ;
+  rdfs:range xsd:anyURI ;
+  rdfs:range xsd:string ;
+  skos:prefLabel "uses software" ;
+  prov:definition "A reference to a software tool or command line " ;
+  TerraCore:hasColumnLabel "uses_software" ;
 .
 TerraDCAT_ap:DataCollection
   rdfs:subClassOf [

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -606,6 +606,53 @@ TerraCore:Donor
   skos:definition "An organism from which a sample or test result is available" ;
   skos:prefLabel "Donor" ;
 .
+TerraCore:DonorTreatmentActivity
+  a owl:Class ;
+  rdfs:label "Donor Treatment" ;
+  rdfs:subClassOf TerraCore:Activity ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasTreatmentType ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:cardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:id ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDonorAgeAtCollection ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDose ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDuration ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasDurationUnit ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasMedication ;
+    ] ;
+  rdfs:subClassOf [
+      a owl:Restriction ;
+      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+      owl:onProperty TerraCore:hasTreatmentOutcome ;
+    ] ;
+  skos:definition "Activities or processes undertaken with the expectation of therapeutic value to the Donor." ;
+  skos:prefLabel "Donor Treatment" ;
+.
 TerraCore:Dose
   a owl:Class ;
   rdfs:label "Dose" ;
@@ -1400,53 +1447,6 @@ TerraCore:SingleCellIsolationActivity
     ] ;
   skos:definition "Activity to separate individual cells or nuclei. " ;
 .
-TerraCore:TreatmentActivity
-  a owl:Class ;
-  rdfs:label "Treatment" ;
-  rdfs:subClassOf TerraCore:Activity ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasTreatmentType ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:cardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:id ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasDonorAgeAtCollection ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasDose ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasDuration ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasDurationUnit ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasMedication ;
-    ] ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-      owl:onProperty TerraCore:hasTreatmentOutcome ;
-    ] ;
-  skos:definition "Activities or processes undertaken with the expectation of therapeutic value." ;
-  skos:prefLabel "Treatment" ;
-.
 TerraCore:UserRestriction
   a obo:DUO_0000026 ;
   rdfs:label "User Restriction" ;
@@ -1970,7 +1970,7 @@ TerraCore:hasDonorAgeAtCollection
 TerraCore:hasDonorAgeAtEvent
   a owl:ObjectProperty ;
   rdfs:domain TerraCore:Activity ;
-  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:domain TerraCore:DonorTreatmentActivity ;
   rdfs:label "hasDonorAgeAtEvent" ;
   rdfs:range TerraCore:Age ;
   skos:definition "A reference to the Age of the Donor at the point in time that the event or administration occured." ;
@@ -1979,7 +1979,7 @@ TerraCore:hasDonorAgeAtEvent
 .
 TerraCore:hasDose
   a owl:DatatypeProperty ;
-  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:domain TerraCore:DonorTreatmentActivity ;
   rdfs:label "has dose" ;
   skos:definition "A reference to the dosage information relevant to this Treatment or Medication." ;
   skos:prefLabel "has dose" ;
@@ -2313,7 +2313,7 @@ TerraCore:hasMeasurementType
 TerraCore:hasMedication
   a owl:DatatypeProperty ;
   rdfs:comment "Recommend term or URL from MEDDRA or RxNORM. Note that this model of a medication is subject to change." ;
-  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:domain TerraCore:DonorTreatmentActivity ;
   rdfs:label "has medication" ;
   rdfs:range xsd:anyURI ;
   rdfs:range xsd:string ;
@@ -2711,7 +2711,7 @@ TerraCore:hasTreatment
   rdfs:domain TerraCore:Donor ;
   rdfs:domain TerraCore:HumanDonor ;
   rdfs:label "hasTreatment" ;
-  rdfs:range TerraCore:TreatmentActivity ;
+  rdfs:range TerraCore:DonorTreatmentActivity ;
   skos:definition "A reference to the therapeutic treatment undertaken for this Donor." ;
   skos:prefLabel "has treatment" ;
   TerraCore:hasColumnLabel "treatment" ;
@@ -2720,7 +2720,7 @@ TerraCore:hasTreatmentOutcome
   a rdf:Property ;
   a owl:DatatypeProperty ;
   rdfs:comment "Should the model define a preferred vocabulary? e.g. positive, negative, no effect?  The specific outcome may need to be more specific, reduced tumor size by  .. but the categories listed are useful." ;
-  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:domain TerraCore:DonorTreatmentActivity ;
   rdfs:label "has treatment outcome" ;
   rdfs:range xsd:string ;
   skos:definition "A reference to the outcome of this Treatment." ;
@@ -2729,7 +2729,7 @@ TerraCore:hasTreatmentOutcome
 TerraCore:hasTreatmentType
   a owl:DatatypeProperty ;
   rdfs:comment "Need to add recommended vocabulary." ;
-  rdfs:domain TerraCore:TreatmentActivity ;
+  rdfs:domain TerraCore:DonorTreatmentActivity ;
   rdfs:label "has treatment type" ;
   rdfs:range xsd:string ;
   skos:prefLabel "has treatment type" ;

--- a/src/terra-core/TerraCoreDataModel.ttl
+++ b/src/terra-core/TerraCoreDataModel.ttl
@@ -1981,7 +1981,7 @@ TerraCore:hasDose
   a owl:DatatypeProperty ;
   rdfs:domain TerraCore:DonorTreatmentActivity ;
   rdfs:label "has dose" ;
-  skos:definition "A reference to the dosage information relevant to this Treatment or Medication." ;
+  skos:definition "A reference to the dosage information relevant to this Donor Treatment or Medication." ;
   skos:prefLabel "has dose" ;
   TerraCore:hasColumnLabel "dose" ;
 .
@@ -2149,7 +2149,7 @@ TerraCore:hasGeneticModificationType
         ) ;
     ] ;
   skos:prefLabel "has genetic modification type" ;
-  TerraCore:hasColumnLabel "genetic_mod_method" ;
+  TerraCore:hasColumnLabel "genetic_mod_type" ;
 .
 TerraCore:hasGenotypicSex
   a owl:DatatypeProperty ;


### PR DESCRIPTION
Added first healthcare entities per Findability Subset proposal.  Measurement, Dose, TreatmentActivity.  Also allow usesSoftware to be a string; many dataset will be more casual about how pipelines, etc. are recorded.  Also removed restrictions on hasPrimaryorMetastaticIndicator.  Not used by any data yet.  See https://broadworkbench.atlassian.net/browse/DM-434. 