### PR TITLE
[DDO-2236] Fix file name mismatch

### DIFF
--- a/webpages/httpd-container.conf
+++ b/webpages/httpd-container.conf
@@ -179,7 +179,7 @@ LoadModule autoindex_module modules/mod_autoindex.so
 #LoadModule dav_lock_module modules/mod_dav_lock.so
 #LoadModule vhost_alias_module modules/mod_vhost_alias.so
 LoadModule negotiation_module modules/mod_negotiation.so
-#LoadModule dir_module modules/mod_dir.so
+LoadModule dir_module modules/mod_dir.so
 #LoadModule imagemap_module modules/mod_imagemap.so
 #LoadModule actions_module modules/mod_actions.so
 #LoadModule speling_module modules/mod_speling.so

--- a/webpages/httpd-container.conf
+++ b/webpages/httpd-container.conf
@@ -427,23 +427,23 @@ Listen ${PORT}
     # error by default with 406
     RewriteRule ^/imports/NCBITaxon_Organisms_subset$ - [R=406]
 
-# /OBI_assay_subset
+# /OBIAssay_subset
     # Rewrite rule to make sure we serve HTML content from the namespace URI if requested
     RewriteCond %{HTTP_ACCEPT} text/html [OR]
     RewriteCond %{HTTP_ACCEPT} application/xhtml\+xml
-    RewriteRule ^/imports/OBI_assay_subset$ /imports/OBI_assay_subset.html [P]
+    RewriteRule ^/imports/OBIAssay_subset$ /imports/OBIAssay_subset.html [P]
 
     # Rewrite rule to make sure we serve the turtle content from the namespace URI by default
     RewriteCond %{HTTP_ACCEPT} application/rdf\+xml [OR]
     RewriteCond %{HTTP_ACCEPT} application/xml [OR]
     RewriteCond %{HTTP_ACCEPT} text/xml
-    RewriteRule ^/imports/OBI_assay_subset$ https://raw.githubusercontent.com/DataBiosphere/terra-interoperability-model/master/releases/2.x/imports/OBI_assay_subset.xml.rdf [P]
-    ProxyPassReverse /imports/OBI_assay_subset https://raw.githubusercontent.com/DataBiosphere/terra-interoperability-model/master/releases/2.x/imports/OBI_assay_subset.xml.rdf
+    RewriteRule ^/imports/OBIAssay_subset$ https://raw.githubusercontent.com/DataBiosphere/terra-interoperability-model/master/releases/2.x/imports/OBIAssay_subset.xml.rdf [P]
+    ProxyPassReverse /imports/OBIAssay_subset https://raw.githubusercontent.com/DataBiosphere/terra-interoperability-model/master/releases/2.x/imports/OBIAssay_subset.xml.rdf
 
-    SetEnvIfExpr "%{REQUEST_URI} =~ m#^/imports/OBI_assay_subset$# && %{HTTP_ACCEPT} =~ m#application/rdf\+xml|application/xml|text/xml#" RETURN_RDF
+    SetEnvIfExpr "%{REQUEST_URI} =~ m#^/imports/OBIAssay_subset$# && %{HTTP_ACCEPT} =~ m#application/rdf\+xml|application/xml|text/xml#" RETURN_RDF
 
     # error by default with 406
-    RewriteRule ^/imports/OBI_assay_subset$ - [R=406]
+    RewriteRule ^/imports/OBIAssay_subset$ - [R=406]
 
 # /OBI_core
     # Rewrite rule to make sure we serve HTML content from the namespace URI if requested


### PR DESCRIPTION
### Changes
* Fix a file name mismatch in redirect rules: `OBI_assay_subset` was renamed in #104 but the Apache config file was not updated accordingly, leading the file to 404.
* Address an issue reported by @kreinold where the links in the index on `/imports` are incorrect. Experimentation showed they are correct with a trailing slash (`/imports/`); it turns out the trailing slash is needed for Apache's directory indexing to work correctly. I have addressed this by enabling the [`mod_dir` module](https://httpd.apache.org/docs/trunk/en/mod/mod_dir.html) which automatically redirects requests without a trailing slash (eg. `/imports` -> `/imports/`). For future reference, this behavior is controlled by the `DirectorySlash` option.